### PR TITLE
add search interface and support for searching by journal

### DIFF
--- a/src/api/handlers/documents.ts
+++ b/src/api/handlers/documents.ts
@@ -110,7 +110,7 @@ export class DocumentsHandler {
           journalId: true,
         },
         orderBy: { createdAt: "desc" },
-        take: 100,
+        // take: 100,
       });
     } else {
       docs = await this.client.document2.findMany({
@@ -121,7 +121,7 @@ export class DocumentsHandler {
           journalId: true,
         },
         orderBy: { createdAt: "desc" },
-        take: 120,
+        // take: 120,
       });
     }
 

--- a/src/container.tsx
+++ b/src/container.tsx
@@ -15,6 +15,7 @@ import Journal from "./journal";
 import { ClientContext } from "./client/context";
 import { getClient } from "./loadclient.electron";
 import { Client } from "./client";
+import { JournalsStoreContext } from './useJournals';
 
 /**
  * Wrap the main container and supply the API client, which
@@ -32,6 +33,7 @@ export default function ClientInjectingContainer() {
   }, []);
 
   if (!client) {
+    // todo: better loading state...
     return <div>¯\_(ヅ)_/¯</div>;
   }
 
@@ -44,8 +46,7 @@ export type ViewState = 'journals' | 'documents' | 'preferences' | { name: 'edit
 
 const Container = observer(() => {
   const [view, setView] = useState<ViewState>("documents");
-  const { journals, loading, loadingErr }  = useJournals();
-  const searchState = useSearch();
+  const { journalsStore, loading, loadingErr }  = useJournals();
 
   if (loading) {
     return (
@@ -71,7 +72,9 @@ const Container = observer(() => {
         selected="preferences"
         setSelected={setView}
       >
-        <Preferences setView={setView} />
+        <JournalsStoreContext.Provider value={journalsStore!}>
+          <Preferences setView={setView} />
+        </JournalsStoreContext.Provider>
       </Layout>
     )
   }
@@ -82,7 +85,9 @@ const Container = observer(() => {
         selected="documents"
         setSelected={setView}
       >
-        <Documents setView={setView} />
+        <JournalsStoreContext.Provider value={journalsStore!}>
+          <Documents setView={setView} />
+        </JournalsStoreContext.Provider>        
       </Layout>
     );
   }
@@ -93,11 +98,13 @@ const Container = observer(() => {
         selected="documents"
         setSelected={setView}
       >
-        <Editor 
-          documentId={view.props.documentId} 
-          // journalId={view.props.journalId} todo: track last selected journal id and pass through
-          setView={setView} 
-        />
+        <JournalsStoreContext.Provider value={journalsStore!}>
+          <Editor 
+            documentId={view.props.documentId} 
+            // journalId={view.props.journalId} todo: track last selected journal id and pass through
+            setView={setView} 
+          />
+        </JournalsStoreContext.Provider>
       </Layout>
     );
   }
@@ -108,7 +115,10 @@ const Container = observer(() => {
         selected={view}
         setSelected={setView}
       >
-        <Journals />
+
+        <JournalsStoreContext.Provider value={journalsStore!}>
+          <Journals />
+        </JournalsStoreContext.Provider>
       </Layout>
     );
   }

--- a/src/journal/components/search/index.tsx
+++ b/src/journal/components/search/index.tsx
@@ -3,9 +3,18 @@ import { TagInput } from "evergreen-ui";
 import { observer, useLocalStore } from "mobx-react-lite";
 import { IJournalsUiStore } from "../../store";
 import { TagSearchStore } from "./store";
+import { TagSearchLoading } from './loading';
 
 interface Props {
-  store: IJournalsUiStore;
+  store: Pick<IJournalsUiStore, "tokens">;
+}
+
+export default function TagSearchContainer(props: Partial<Props>) {
+  if (!props.store) {
+    return <TagSearchLoading />
+  }
+
+  return <ObvsTagSearch store={props.store} />
 }
 
 function TagSearch(props: Props) {
@@ -45,4 +54,4 @@ function TagSearch(props: Props) {
   );
 }
 
-export default observer(TagSearch);
+const ObvsTagSearch = observer(TagSearch);

--- a/src/journal/components/search/loading.tsx
+++ b/src/journal/components/search/loading.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { TagInput } from "evergreen-ui";
+import { IJournalsUiStore } from "../../store";
+
+interface Props {
+  store?: Pick<IJournalsUiStore, "tokens">;
+}
+
+export function TagSearchLoading(props: Props) {
+  return (
+    <TagInput
+      flexGrow={1}
+      inputProps={{ placeholder: "Search journals" }}
+      disabled
+    />
+  );
+}
+

--- a/src/useJournals.ts
+++ b/src/useJournals.ts
@@ -3,8 +3,31 @@ import React from "react";
 import client, { Client } from "./client";
 import { JournalResponse } from "./api/client/journals";
 
+export class JournalsStore {
+  journals: JournalResponse[];
+  constructor(journals: JournalResponse[]) {
+    this.journals = journals;
+  }
+
+  static async create() {
+    const journals = await client.v2.journals.list();
+    return new JournalsStore(journals);
+  }
+
+  idForName = (name: string) => {
+    const nameLower = name.toLowerCase();
+    const match = this.journals.find((j) => j.name === nameLower);
+    if (match) return match.id;
+  };
+}
+
+export const JournalsStoreContext = React.createContext<JournalsStore>(
+  null as any
+);
+
 export function useJournals() {
   const [journals, setJournals] = React.useState<JournalResponse[]>();
+  const [journalsStore, setJournalsStore] = React.useState<JournalsStore>();
   const [loading, setLoading] = React.useState(true);
   const [loadingErr, setLoadingErr] = React.useState(null);
 
@@ -14,10 +37,12 @@ export function useJournals() {
 
     async function load() {
       try {
+        const journalStore = await JournalsStore.create();
         const journals = await client.v2.journals.list();
         if (!isEffectMounted) return;
 
         setJournals(journals);
+        setJournalsStore(journalStore);
         setLoading(false);
       } catch (err) {
         if (!isEffectMounted) return;
@@ -33,5 +58,5 @@ export function useJournals() {
     };
   }, []);
 
-  return { journals, loading, loadingErr };
+  return { journals, journalsStore, loading, loadingErr };
 }

--- a/src/views/documents/index.tsx
+++ b/src/views/documents/index.tsx
@@ -139,7 +139,7 @@ function DocumentsContainer(props: Props) {
     return jrnl.name;
   }
 
-  const docs = searchStore.docs.map(doc => {
+  const docs = searchStore.docs.slice(0, 100).map(doc => {
     return (
     <Pane key={doc.id} style={{display: 'flex',}} onClick={() => edit(doc.id)}>
       <div style={{marginRight: '24px'}}>{doc.createdAt.slice(0,10)}</div>

--- a/src/views/edit/index.tsx
+++ b/src/views/edit/index.tsx
@@ -161,7 +161,7 @@ const DocumentEditView = observer((props: DocumentEditProps) => {
           `}
           onChange={(e: any) => document.title = e.target.value}
           value={document.title}
-          placeholder="An optional title for this document"
+          placeholder="Untitled"
           disabled={document.saving}
         />
       </div>


### PR DESCRIPTION
Adds support for `in:` operator to search by journal. Not intuitive, no feedback or auto-suggest, just basic filtering by journal

<img width="532" alt="Screen Shot 2021-10-01 at 9 48 47 AM" src="https://user-images.githubusercontent.com/1010084/135640619-40c49455-1cb0-4903-b6d6-521abb9fdd26.png">
.
