### PR TITLE
Fix build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ tmp/
 # build output
 dist/
 packaged/
+
+# Generated prisma client
+# Configured in schema.prisma
+prisma/

--- a/README.md
+++ b/README.md
@@ -4,24 +4,16 @@
 
 
 ## Migrating the database
-This project is using Prisma. If there are changes to the `schema.prisma` file, re-generate the client:
+This project is using Prisma. If there are changes to the `schema.prisma` file, a script in the project auto-runs migrations and re-generates the prisma client. However, before finalizing generate migrations:
 
 ```
-npx prisma generate
+npx prisma migrate dev --name <name_goes_here>
 ```
 
-...that doesn't migrate the database it just makes the client...
-.... todo: How to migrate in dev, production...
+This won't work in production: https://github.com/cloverich/chronicles/issues/63 and the long term solution to migrations and the backend architecture / db in general is tbd. 
 
 ### Database file
-The SQLite database file is designated by an environment variable (`DATABASE_URL`) specified in the [settings.json](https://github.com/nathanbuchar/electron-settings) file. 
-
-
-### Legacy Code and notes
-I haven't setup migrations or database versioning. Between releases, you may need to reset the database. Two ways to do this:
-
-- Find the sqlite database file and delete it
-- Start the app with `CHRONICLES_RESCHEMA` to to true
+The SQLite database file is designated by an environment variable (`DATABASE_URL`) specified in the [settings.json](https://github.com/nathanbuchar/electron-settings) file. It can be configured in preferences. But see above.
 
 ## Development
 The app is a typical Electron dev setup, but serves the UI from webpack dev server while in development. To start the app you'll need to start both the webpack dev server and electron.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ This project is using Prisma. If there are changes to the `schema.prisma` file, 
 npx prisma generate
 ```
 
+...that doesn't migrate the database it just makes the client...
+.... todo: How to migrate in dev, production...
+
 ### Database file
 The SQLite database file is designated by an environment variable (`DATABASE_URL`) specified in the [settings.json](https://github.com/nathanbuchar/electron-settings) file. 
 

--- a/build.sh
+++ b/build.sh
@@ -34,6 +34,13 @@ fi
 echo "Copying electron folder"
 cp -r src/electron dist/
 
+# Generate prisma database client
+# Then copy it to the output directory
+# NOTE: Does this account for native binaries? ¯\_(ツ)_/¯ 
+# https://www.prisma.io/docs/reference/api-reference/prisma-schema-reference#binarytargets-options
+npx prisma generate
+cp -r src/prisma dist/prisma
+
 # compile server code, which is typescript, to dist
 echo "Compiling backend typescript and outputting to $outdir"
 npx tsc --outDir dist/

--- a/build.sh
+++ b/build.sh
@@ -34,6 +34,9 @@ fi
 echo "Copying electron folder"
 cp -r src/electron dist/
 
+# todo: inspect database and determine if migrations were generated
+# ...this is a post-build, pre-release integration test
+
 # Generate prisma database client
 # Then copy it to the output directory
 # NOTE: Does this account for native binaries? ¯\_(ツ)_/¯ 
@@ -50,7 +53,10 @@ npx webpack --config webpack.js
 
 # copy package.json, required by electron to know how to start
 cp package.json dist/
+cp yarn.lock dist/
 
+# todo: This is installing dev dependencies which, because of webpack, should not be needed.
+# When I use install --production, the final build complains it cannot find electron. Sigh.
 cd dist/ && yarn
 
 cd ../

--- a/package.js
+++ b/package.js
@@ -40,6 +40,7 @@ packager({
   dir: srcDir,
   out: outDir,
   // … other options
+  // Documentation does this in afterCopy. Why did I do this in afterPrune?
   afterPrune: [(buildPath, electronVersion, platform, arch, callback) => {
     console.log('rebuilding...', buildPath, electronVersion, platform, arch);
     rebuild({ buildPath, electronVersion, arch })

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   },
   "dependencies": {
     "@koa/router": "^9.3.1",
-    "@prisma/client": "^2.28.0",
     "ajv": "^8.6.2",
     "ajv-formats": "^2.1.0",
     "better-sqlite3": "^7.1.0",
@@ -37,6 +36,7 @@
     "unified": "^9.1.0"
   },
   "devDependencies": {
+    "@prisma/client": "^2.28.0",
     "@types/better-sqlite3": "^5.4.0",
     "@types/chai": "^4.2.11",
     "@types/klaw": "^3.0.1",

--- a/schema.prisma
+++ b/schema.prisma
@@ -1,6 +1,7 @@
 generator client {
   provider = "prisma-client-js"
   previewFeatures = ["referentialActions"]
+  output   = "./src/prisma/client"
 }
 
 datasource db {

--- a/src/api/client/preferences.ts
+++ b/src/api/client/preferences.ts
@@ -1,5 +1,6 @@
 import ky from "ky-universal";
 type Ky = typeof ky;
+import settings from "electron-settings";
 
 export interface Preferences {
   DATABASE_URL: string;
@@ -9,14 +10,17 @@ export interface Preferences {
 export class PreferencesClient {
   constructor(private ky: Ky) {}
 
-  get = (): Promise<Preferences> => {
-    return this.ky("v2/preferences").json();
+  get = async (): Promise<Preferences> => {
+    const settingsJson = settings.getSync();
+    return settingsJson as unknown as Preferences;
+    // return this.ky("v2/preferences").json();
   };
 
-  update = (preferences: Preferences): Promise<any> => {
-    return this.ky("v2/preferences", {
-      method: "post",
-      json: preferences,
-    }).json();
-  };
+  // update = (preferences: Preferences): Promise<any> => {
+
+  //   return this.ky("v2/preferences", {
+  //     method: "post",
+  //     json: preferences,
+  //   }).json();
+  // };
 }

--- a/src/api/handlers/documents.ts
+++ b/src/api/handlers/documents.ts
@@ -1,6 +1,5 @@
-import { PrismaClient } from "@prisma/client";
+import { PrismaClient } from "../../prisma/client";
 import { RouterContext } from "@koa/router";
-import { Prisma } from "@prisma/client";
 import { parser, stringifier } from "../../markdown";
 
 // My first attempt at JSON schema for validating the document save request

--- a/src/api/handlers/index.ts
+++ b/src/api/handlers/index.ts
@@ -3,7 +3,6 @@ import { DocumentsHandler } from "./documents";
 import { PreferencesHandler } from "./preferences";
 import { FilesHandler } from "./files";
 import { PrismaClient } from "../../prisma/client";
-import settings from "electron-settings";
 
 export interface Handlers {
   journals: Journals;
@@ -16,20 +15,13 @@ export interface Handlers {
  * Setup API route handlers (construction, initialization, validation, DI)
  */
 export default async function handlers(): Promise<Handlers> {
-  // Since this is a forked process, we don't have electron runtime and
-  // electron-settings can't use it either. By telling settings where to look
-  // it apparently won't make any other electron calls, and so this (non electron)
-  // process can use electron-settings so long as it manually sets the directory
-  // ...to the default, passed from the main (electron) startup process through
-  // an environment variable. Wow this is getting hacky...
-  if (!process.env.USER_DATA_DIR) {
-    throw new Error("missing environment variable: USER_DATA_DIR");
-  } else {
-    console.log(
-      "configuring electron-settings to use ",
-      process.env.USER_DATA_DIR
+  // Because we can't access electron-settings in this forked process,
+  // rely on this environment variable for the location of user_files
+  if (!process.env.USER_FILES_DIR) {
+    console.error(process.env);
+    throw new Error(
+      "handlers setup is missing environment variable: USER_FILES_DIR"
     );
-    settings.configure({ dir: process.env.USER_DATA_DIR });
   }
 
   const client = new PrismaClient();
@@ -37,6 +29,6 @@ export default async function handlers(): Promise<Handlers> {
     journals: new Journals(client),
     documents: new DocumentsHandler(client),
     preferences: new PreferencesHandler(),
-    files: await FilesHandler.create(process.env.USER_DATA_DIR!),
+    files: new FilesHandler(process.env.USER_FILES_DIR!),
   };
 }

--- a/src/api/handlers/index.ts
+++ b/src/api/handlers/index.ts
@@ -2,7 +2,7 @@ import { Journals } from "./journals";
 import { DocumentsHandler } from "./documents";
 import { PreferencesHandler } from "./preferences";
 import { FilesHandler } from "./files";
-import { PrismaClient } from "@prisma/client";
+import { PrismaClient } from "../../prisma/client";
 import settings from "electron-settings";
 
 export interface Handlers {

--- a/src/api/handlers/journals.ts
+++ b/src/api/handlers/journals.ts
@@ -1,6 +1,5 @@
-import { PrismaClient } from "@prisma/client";
+import { PrismaClient, Prisma } from "../../prisma/client";
 import { RouterContext } from "@koa/router";
-import { Prisma } from "@prisma/client";
 
 export interface IJournal {
   // display name

--- a/src/api/handlers/preferences.ts
+++ b/src/api/handlers/preferences.ts
@@ -1,5 +1,5 @@
 import { RouterContext } from "@koa/router";
-import settings from "electron-settings";
+// import settings from "electron-settings";
 
 /**
  * The Preferences handler provides an API into electron-settings.
@@ -8,7 +8,7 @@ export class PreferencesHandler {
   get = async ({ response }: RouterContext) => {
     response.status = 200;
     response.body = {
-      ...settings.getSync(),
+      // ...settings.getSync(),
       // The schema.prisma file declares this environment variable as
       // where it looks for the database, and its provided by the start-up
       // process

--- a/src/app.html
+++ b/src/app.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="UTF-8" />
-  <title>Pragma</title>
+  <title>Chronicles</title>
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;1,100;1,200;1,300;1,400;1,500;1,600;1,700&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Serif:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;1,100;1,200;1,300;1,400;1,500;1,600;1,700&display=swap" rel="stylesheet">
 </head>

--- a/src/electron/userFilesInit.js
+++ b/src/electron/userFilesInit.js
@@ -1,0 +1,77 @@
+const settings = require('electron-settings');
+const path = require('path');
+const fs = require("fs");
+const mkdirp = require("mkdirp");
+
+exports.initUserFilesDir = function initUserFilesDir(userDataDir) {
+  // I would prefer to do this in a formal start-up routine, although I suppose creating
+  // api handlers is a reasonable place to have that logic.
+  // todo: validate path is valid, readable, writeable
+  let assetsPath = settings.getSync("USER_FILES_DIR");
+
+  // Create and set a default directory if it does not exist
+  if (!assetsPath) {
+    const defaultUserFilesDir = path.join(
+      userDataDir,
+      "chronicles_user_images"
+    );
+    console.log(
+      `USER_FILES_DIR not found in settings. Using ${userDataDir} and udpating settings`
+    );
+
+    settings.setSync("USER_FILES_DIR", defaultUserFilesDir);
+    assetsPath = defaultUserFilesDir;
+  }
+
+  // Not sure, but better something than silence
+  if (typeof assetsPath !== "string") {
+    console.error(
+      "assets path is not a string",
+      assetsPath,
+      "typeof: ",
+      typeof assetsPath
+    );
+    throw new Error(
+      "Assets path is not a string, FilesHandler cannot proceed without the assetsPath directory being a string pointing to a valid, accessible file path"
+    );
+  }
+
+  console.log("serving user assets from", assetsPath);
+
+  try {
+    ensureDir(assetsPath);
+
+    // todo: no way to keep this cached path in sync if settings changes
+    // since that is performed in the main process
+    // return new FilesHandler(/*assetsPath*/);
+  } catch (err) {
+    throw new Error(
+      `FilesHandler cannot read or write ${assetsPath}. Access is necessary to upload and serve user files!`
+    );
+  }
+}
+
+
+  /**
+   * Borrowed from api files, since its typescript and this is not
+   * Reconcile that later
+   */
+function ensureDir(directory) {
+    try {
+      const dir = fs.statSync(directory);
+      if (!dir.isDirectory()) {
+        throw new Error(
+          `ensureDir called but ${directory} already exists as a file`
+        );
+      }
+    } catch (err) {
+      if (err.code !== "ENOENT") throw err;
+      mkdirp.sync(directory);
+    }
+
+    // NOTE: Documentation suggests Windows may report ok here, but then choke
+    // when actually writing. Better to move this logic to the actual file
+    // upload handlers.
+    fs.accessSync(directory, fs.constants.R_OK | fs.constants.W_OK);
+  }
+

--- a/src/importChronicles.ts
+++ b/src/importChronicles.ts
@@ -194,6 +194,12 @@ function splitOnTitle(
   return documents;
 }
 
-importChronicles().then(() => {
-  process.exit(0);
-}, console.error);
+importChronicles().then(
+  () => {
+    process.exit(0);
+  },
+  (err) => {
+    console.error(err);
+    process.exit(1);
+  }
+);

--- a/src/importChronicles.ts
+++ b/src/importChronicles.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from "@prisma/client";
+import { PrismaClient } from "./prisma/client";
 import { Files } from "./api/files";
 import { parser, stringifier } from "./markdown";
 import { Root, Content } from "mdast";

--- a/src/views/documents/index.tsx
+++ b/src/views/documents/index.tsx
@@ -56,20 +56,32 @@ import { ViewState } from '../../container';
 interface Props extends React.PropsWithChildren<{}> {
   setView: React.Dispatch<React.SetStateAction<ViewState>>
   store?: SearchV2Store;
+  disableDocCreate?: boolean;
 }
 
 
 const Layout = observer(function LayoutNaked(props: Partial<Props>) {
-  return (
-    <Pane>
+  // conditionally show document create button.
+  function createDocumentsView() {
+    if (!props.setView || props.disableDocCreate) return;
+
+    return (
+      <>
         <Pane marginBottom={8}>
           <TagSearch store={props.store} />
         </Pane>
         <Pane>
-          <a onClick={props.setView ? () => props.setView!({ name: 'edit', props: {}}): () => {}}>
+          <a onClick={() => props.setView!({ name: 'edit', props: {}})}>
             Create new
           </a>
         </Pane>
+      </>
+    )
+  }
+
+  return (
+    <Pane>
+      {createDocumentsView()}
 
       <Pane marginTop={24}>
         {props.children}
@@ -115,17 +127,17 @@ function DocumentsContainer(props: Props) {
   if (!searchStore.docs.length) {
     if (journalsStore.journals.length) {
       return (
-        <Layout store={searchStore}>
+        <Layout store={searchStore} setView={props.setView}>
           <Heading>No documents found</Heading>
           <Paragraph>Broaden your search, or add more documents.</Paragraph>
         </Layout>
       );
     } else {
       return (
-        <Layout store={searchStore}>
+        <Layout store={searchStore} disableDocCreate>
           <Heading>No journals added</Heading>
           <Paragraph>
-            Use the config link in the navbar to create a new journal.
+            Use the preferences link in the navbar to create a new journal.
           </Paragraph>
         </Layout>
       );

--- a/src/views/preferences/index.tsx
+++ b/src/views/preferences/index.tsx
@@ -73,7 +73,7 @@ export default function Preferences(props: Props) {
         <p>Chronicles images and other user files are stored in the `USER_FILES` directory</p>
         <p>This file is located at:</p>
         <p><code>{preferences.USER_FILES_DIR}</code></p>
-        <p>To change the direcotory location, <b>first</b> move the existing directory to the desired location, and then select the new location with th ebutton below</p>
+        <p>To change the directory location, <b>first</b> move the existing directory to the desired location, and then select the new location with th ebutton below</p>
 
         {/* todo: https://stackoverflow.com/questions/8579055/how-do-i-move-files-in-node-js/29105404#29105404 */}
         <Button isLoading={loading} disabled={loading} onClick={openDialogUserFiles}>Select new directory</Button>


### PR DESCRIPTION
The build broke a while ago, and its time to fix it. 

https://www.prisma.io/docs/concepts/components/prisma-migrate

- [x] change prisma output folder, pick it up in build script
- [x]  fix a few embarrassing errors
- [x]  simplify `file:` prefix handling for SQLite file
- [ ] figure out migrations in dev and production
- [x] Update README to account for migrations
- [ ] Update README with how to start via terminal for debugging packaged build
- [x] ...not really part of PR, but add a tracking issue for multi-platform support and make a note about Prisma binraries

I wonder if there is a way to run the migrations via script within the running app. It is kind of a weird setup, Prisma was just convenient. Hoping I can get it working and punt on the longer term database decision until a future release. 