### PR TITLE
pre-select current or active journals

### DIFF
--- a/src/container.tsx
+++ b/src/container.tsx
@@ -13,7 +13,10 @@ import { Alert, Pane } from "evergreen-ui";
 import { Routes, Route, Navigate } from "react-router-dom";
 import { useSearchParams } from "react-router-dom";
 import useClient from "./hooks/useClient";
-import { SearchV2Store } from "./views/documents/SearchStore";
+import {
+  SearchV2Store,
+  SearchStoreContext,
+} from "./views/documents/SearchStore";
 
 export default observer(function Container() {
   const { journalsStore, loading, loadingErr } = useJournalsLoader();
@@ -63,16 +66,21 @@ export default observer(function Container() {
 
   return (
     <JournalsStoreContext.Provider value={journalsStore!}>
-      <Layout>
-        <Routes>
-          <Route element={<Journals />} path="journals" />
-          <Route element={<Preferences />} path="preferences" />
-          <Route element={<Editor />} path="edit/new" />
-          <Route element={<Editor />} path="edit/:document" />
-          <Route element={<Documents store={searchStore} />} path="documents" />
-          <Route path="*" element={<Navigate to="documents" replace />} />
-        </Routes>
-      </Layout>
+      <SearchStoreContext.Provider value={searchStore}>
+        <Layout>
+          <Routes>
+            <Route element={<Journals />} path="journals" />
+            <Route element={<Preferences />} path="preferences" />
+            <Route element={<Editor />} path="edit/new" />
+            <Route element={<Editor />} path="edit/:document" />
+            <Route
+              element={<Documents store={searchStore} />}
+              path="documents"
+            />
+            <Route path="*" element={<Navigate to="documents" replace />} />
+          </Routes>
+        </Layout>
+      </SearchStoreContext.Provider>
     </JournalsStoreContext.Provider>
   );
 });

--- a/src/preload/client/journals.ts
+++ b/src/preload/client/journals.ts
@@ -48,6 +48,7 @@ export class JournalsClient {
   };
 
   remove = (journal: { id: string }): Promise<JournalResponse[]> => {
+    // TODO: ensure there is always at least one journal. Deleting the last journal breaks the app.
     this.db
       .prepare("delete from journals where id = :id")
       .run({ id: journal.id });

--- a/src/views/documents/SearchStore.ts
+++ b/src/views/documents/SearchStore.ts
@@ -1,3 +1,4 @@
+import { createContext } from "react";
 import { IClient } from "../../hooks/useClient";
 import { observable, IObservableArray, computed, action } from "mobx";
 import { JournalsStore } from "../../hooks/stores/journals";
@@ -18,6 +19,8 @@ interface SearchQuery {
   texts?: string[];
   limit?: number;
 }
+
+export const SearchStoreContext = createContext<SearchV2Store>(null as any);
 
 export class SearchV2Store {
   @observable docs: SearchItem[] = [];
@@ -155,6 +158,14 @@ export class SearchV2Store {
     this.setTokens([]);
     this.addTokens(searchStr);
   };
+
+  @computed get selectedJournals(): string[] {
+    // Grab the journal names from the tokens
+    // todo: Typescript doesn't know when I filter to type === 'in' its InTokens
+    return this._tokens
+      .filter((t) => t.type === "in")
+      .map((t) => t.value) as string[];
+  }
 
   @computed
   get searchTokens() {

--- a/src/views/edit/index.tsx
+++ b/src/views/edit/index.tsx
@@ -14,13 +14,17 @@ import { JournalsStoreContext } from "../../hooks/useJournalsLoader";
 import Toolbar from "./toolbar";
 import { useParams, useNavigate } from "react-router-dom";
 import { DebugView } from "./DebugView";
+import { SearchStoreContext } from "../documents/SearchStore";
 
 // Loads document, with loading and error placeholders
 function DocumentLoadingContainer() {
   const journalsStore = useContext(JournalsStoreContext);
+  const searchStore = useContext(SearchStoreContext);
   const { document: documentId } = useParams();
+
   const { document, loadingError } = useEditableDocument(
-    journalsStore.journals,
+    searchStore,
+    journalsStore,
     documentId,
   );
 


### PR DESCRIPTION
- put search store into context (todo: refactor component drilling to pull from context)
- when creating new documents, if the search is scoped to a journal, default the new document to the selected journal
- when creating new documents, if search is NOT scoped, default to the first ACTIVE journal

closes #102 