### PR TITLE
upgrade esbuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,7 @@
 
 Electron based markdown journaling application, in the spirit of [incremental note taking][incr-notes].
 
-**Status**: Hobby project, prototyping and re-working UX to try out various concepts with little regard for usability, stability, or appearances. Will remove this clause when I can guarantee your notes won't _poof_ and the experience isn't confusing. Reach out if you are interested in journaling concepts and I'll provide a tour.
-
-Tech stack:
-
-- Electron and esbuild
-- Typescript
-- React and mobx
-- Slate and Plate (Notion style WSYIWYG)
+**Status**: Hobby project, prototyping and re-working UX to try out various concepts with little regard for usability, stability, or appearances.
 
 ## Development
 
@@ -28,9 +21,16 @@ yarn run electron-rebuild
 
 See scripts/dev.js for specifics on how the source files are compiled and re-loaded in development.
 
+### Tech stack
+
+- Electron and esbuild
+- Typescript
+- React and mobx
+- Slate and Plate (Notion style WSYIWYG)
+
 ## Build and release
 
-- Read and use the `build.sh` script
+- Use `yarn build`
 - Make a Github release
 
 At a high level, the build is comprised of:

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint:types:check": "tsc --noEmit --skipLibCheck",
     "postinstall": "yarn run electron-rebuild",
     "prestart": "tailwindcss -i ./src/index.css -o ./src/index-compiled.css",
-    "prebuild": "tailwindcss -i ./src/index.css -o ./src/index-compiled.css",
+    "prebuild": "yarn run lint && tailwindcss -i ./src/index.css -o ./src/index-compiled.css",
     "start": "node ./scripts/dev.js",
     "test": "mocha -r esm -r ts-node/register src/**/*.test.ts",
     "test:one": "mocha -r ts-node/register -r esm"
@@ -50,7 +50,7 @@
     "date-fns": "^3.3.1",
     "electron": "^28.2.0",
     "emotion": "^10.0.27",
-    "esbuild": "^0.13.8",
+    "esbuild": "^0.20.0",
     "esm": "^3.2.25",
     "evergreen-ui": "^7.1.9",
     "klaw": "^3.0.0",

--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -3,90 +3,49 @@ const cp = require("child_process");
 const electron = require("electron");
 const lodash = require("lodash");
 
-// After successful rebuild, log results
-function afterRebuild(name, cb) {
-  return (error, result) => {
-    if (error) {
-      console.error(`${name} bundle completed with error`, error);
-    } else {
-      console.log(`${name} bundle completed`);
-      restartElectron();
-    }
+// Builds and watches the application for development
+// Bundles the renderer, preload, and main processes, and
+// starts Electron, then watches for changes
+
+const startTracker = new Set();
+let didStart = false;
+
+// esbuild callbacks work as plugins; this one handles (re)starting the electron
+// process after the application bundles are built
+function startElectronPlugin(name) {
+  return {
+    name: "(Re)start Electron",
+    setup(build) {
+      build.onEnd((result) => {
+        // NOTE: This will not handle type checking; see type checking call below
+        if (result.errors.length) {
+          console.error(`${name} bundle completed with errors`, result.errors);
+        } else {
+          console.log(`${name} bundle completed`);
+          startTracker.add(name);
+        }
+
+        if (startTracker.size !== 3) return;
+
+        if (didStart) {
+          restartElectron();
+        } else {
+          didStart = true;
+          startElectron();
+        }
+      });
+    },
   };
 }
-
-// After successful build, log results
-function afterBuild(name) {
-  return ({ errors, warnings, ...rest }) => {
-    if (errors.length) {
-      console.error(`${name} bundle completed with errors`, errors);
-    } else if (warnings.length) {
-      console.warn(`${name} bundle completed with warnings`, warnings);
-    } else {
-      console.log(`${name} bundle completed`);
-    }
-
-    // note: until I see errors or warnings, unsure if I should have any special behavior...
-    startElectron();
-  };
-}
-
-// build renderer bundle
-esbuild
-  .build({
-    entryPoints: ["src/index.tsx"],
-    outfile: "src/renderer.bundle.js",
-    bundle: true,
-    platform: "browser",
-    watch: {
-      onRebuild: afterRebuild("renderer"),
-    },
-  })
-  .then(afterBuild("renderer"), console.error);
-
-// build preload bundle
-esbuild
-  .build({
-    entryPoints: ["src/preload/index.ts"],
-    outfile: "src/preload.bundle.js",
-    bundle: true,
-    platform: "node",
-    external: ["knex", "electron", "electron-store", "better-sqlite3"],
-    watch: {
-      onRebuild: afterRebuild("preload"),
-    },
-  })
-  .then(afterBuild("preload"), console.error);
-
-// build electron main bundle
-esbuild
-  .build({
-    entryPoints: ["src/electron/index.js"],
-    outfile: "src/main.bundle.js",
-    bundle: true,
-    platform: "node",
-    external: ["electron", "electron-store", "better-sqlite3"],
-    watch: {
-      onRebuild: afterRebuild("main"),
-    },
-  })
-  .then(afterBuild("main"), console.error);
 
 // For holding the spawned Electron main process, so it can
 // be .kill()'ed on re-start
 let eprocess;
 
-// Track build completions, see below
-let startCounter = 0;
-
-// Start the electron main process
+// Start the electron main process (first time)
 function startElectron() {
-  // Naive way to wait for all three bundles before starting the first time, since
-  // main bundle completes quickest
-  startCounter++;
-  if (startCounter < 3) return;
-
   console.log("starting electron");
+  checkTypes();
   eprocess = cp.spawn(`${electron}`, ["src/main.bundle.js"], {
     stdio: "inherit",
   });
@@ -98,10 +57,17 @@ function startElectron() {
 }
 
 // Re-start the main process
+// todo: This works, but is heavy-handed since it fully re-starts the process each time.
+// Ideally renderer code would hot-reload, or merely refresh and load from a dev-server
+// instead or restarting electron
 const restartElectron = lodash.debounce(function startElectron() {
   if (eprocess) eprocess.kill("SIGTERM");
 
-  console.log("starting electron");
+  // todo: This was a quick hack to get type errors to show up in console. Re-write this as a
+  // plugin that checks the relevant types (renderer, preload) and fails the build (and, ideally,
+  // is incremental or something, rather than a fresh sub-process)
+  checkTypes();
+  console.log("restarting electron");
   eprocess = cp.spawn(`${electron}`, ["src/main.bundle.js"], {
     stdio: "inherit",
   });
@@ -111,3 +77,56 @@ const restartElectron = lodash.debounce(function startElectron() {
     process.exit(1);
   });
 }, 200);
+
+const checkTypes = lodash.debounce(function checkTypes() {
+  const typesProcess = cp.spawn("yarn", ["tsc", "--noEmit"], {
+    stdio: "inherit",
+  });
+
+  typesProcess.on("error", (error) => {
+    console.error("types error", error, error.message);
+    process.exit(1);
+  });
+}, 200);
+
+async function watchRenderer() {
+  const ctxRenderer = await esbuild.context({
+    entryPoints: ["src/index.tsx"],
+    outfile: "src/renderer.bundle.js",
+    bundle: true,
+    platform: "browser",
+    plugins: [startElectronPlugin("renderer")],
+  });
+
+  await ctxRenderer.watch();
+}
+
+async function watchPreload() {
+  const ctxPreload = await esbuild.context({
+    entryPoints: ["src/preload/index.ts"],
+    outfile: "src/preload.bundle.js",
+    bundle: true,
+    platform: "node",
+    external: ["knex", "electron", "electron-store", "better-sqlite3"],
+    plugins: [startElectronPlugin("preload")],
+  });
+
+  await ctxPreload.watch();
+}
+
+async function watchMain() {
+  const ctxMain = await esbuild.context({
+    entryPoints: ["src/electron/index.js"],
+    outfile: "src/main.bundle.js",
+    bundle: true,
+    platform: "node",
+    external: ["electron", "electron-store", "better-sqlite3"],
+    plugins: [startElectronPlugin("main")],
+  });
+
+  await ctxMain.watch();
+}
+
+watchMain();
+watchPreload();
+watchRenderer();

--- a/scripts/production.js
+++ b/scripts/production.js
@@ -1,50 +1,47 @@
 const esbuild = require("esbuild");
-const cp = require("child_process");
-const electron = require("electron");
 
 // After successful build, log results
 function afterBuild(name) {
-  return ({ errors, warnings, ...rest }) => {
-    console.log(rest);
-    if (errors.length) {
-      console.error(`${name} bundle completed with errors`, errors);
-      process.exit(1);
-    } else if (warnings.length) {
-      console.warn(`${name} bundle completed with warnings`, warnings);
-    } else {
-      console.log(`${name} bundle completed`);
-    }
+  return {
+    name: `after-build-${name}`,
+    setup(build) {
+      build.onEnd((result) => {
+        if (result.errors.length) {
+          console.error(`${name} bundle completed with errors`, errors);
+          process.exit(1);
+        } else {
+          console.log(`${name} bundle completed`);
+        }
+      });
+    },
   };
 }
 
 // build renderer bundle
-esbuild
-  .build({
-    entryPoints: ["src/index.tsx"],
-    outfile: "src/renderer.bundle.js",
-    bundle: true,
-    platform: "browser",
-  })
-  .then(afterBuild("renderer"), console.error);
+esbuild.build({
+  entryPoints: ["src/index.tsx"],
+  outfile: "src/renderer.bundle.js",
+  bundle: true,
+  platform: "browser",
+  plugins: [afterBuild("renderer")],
+});
 
 // build preload bundle
-esbuild
-  .build({
-    entryPoints: ["src/preload/index.ts"],
-    outfile: "src/preload.bundle.js",
-    bundle: true,
-    platform: "node",
-    external: ["knex", "electron", "electron-store", "better-sqlite3"],
-  })
-  .then(afterBuild("preload"), console.error);
+esbuild.build({
+  entryPoints: ["src/preload/index.ts"],
+  outfile: "src/preload.bundle.js",
+  bundle: true,
+  platform: "node",
+  external: ["knex", "electron", "electron-store", "better-sqlite3"],
+  plugins: [afterBuild("preload")],
+});
 
 // build electron main bundle
-esbuild
-  .build({
-    entryPoints: ["src/electron/index.js"],
-    outfile: "src/main.bundle.js",
-    bundle: true,
-    platform: "node",
-    external: ["electron", "electron-store", "better-sqlite3"],
-  })
-  .then(afterBuild("main"), console.error);
+esbuild.build({
+  entryPoints: ["src/electron/index.js"],
+  outfile: "src/main.bundle.js",
+  bundle: true,
+  platform: "node",
+  external: ["electron", "electron-store", "better-sqlite3"],
+  plugins: [afterBuild("main")],
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -417,6 +417,121 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
+"@esbuild/aix-ppc64@0.20.0":
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.20.0.tgz#509621cca4e67caf0d18561a0c56f8b70237472f"
+  integrity sha512-fGFDEctNh0CcSwsiRPxiaqX0P5rq+AqE0SRhYGZ4PX46Lg1FNR6oCxJghf8YgY0WQEgQuh3lErUFE4KxLeRmmw==
+
+"@esbuild/android-arm64@0.20.0":
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.20.0.tgz#109a6fdc4a2783fc26193d2687827045d8fef5ab"
+  integrity sha512-aVpnM4lURNkp0D3qPoAzSG92VXStYmoVPOgXveAUoQBWRSuQzt51yvSju29J6AHPmwY1BjH49uR29oyfH1ra8Q==
+
+"@esbuild/android-arm@0.20.0":
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.20.0.tgz#1397a2c54c476c4799f9b9073550ede496c94ba5"
+  integrity sha512-3bMAfInvByLHfJwYPJRlpTeaQA75n8C/QKpEaiS4HrFWFiJlNI0vzq/zCjBrhAYcPyVPG7Eo9dMrcQXuqmNk5g==
+
+"@esbuild/android-x64@0.20.0":
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.20.0.tgz#2b615abefb50dc0a70ac313971102f4ce2fdb3ca"
+  integrity sha512-uK7wAnlRvjkCPzh8jJ+QejFyrP8ObKuR5cBIsQZ+qbMunwR8sbd8krmMbxTLSrDhiPZaJYKQAU5Y3iMDcZPhyQ==
+
+"@esbuild/darwin-arm64@0.20.0":
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.20.0.tgz#5c122ed799eb0c35b9d571097f77254964c276a2"
+  integrity sha512-AjEcivGAlPs3UAcJedMa9qYg9eSfU6FnGHJjT8s346HSKkrcWlYezGE8VaO2xKfvvlZkgAhyvl06OJOxiMgOYQ==
+
+"@esbuild/darwin-x64@0.20.0":
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.20.0.tgz#9561d277002ba8caf1524f209de2b22e93d170c1"
+  integrity sha512-bsgTPoyYDnPv8ER0HqnJggXK6RyFy4PH4rtsId0V7Efa90u2+EifxytE9pZnsDgExgkARy24WUQGv9irVbTvIw==
+
+"@esbuild/freebsd-arm64@0.20.0":
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.0.tgz#84178986a3138e8500d17cc380044868176dd821"
+  integrity sha512-kQ7jYdlKS335mpGbMW5tEe3IrQFIok9r84EM3PXB8qBFJPSc6dpWfrtsC/y1pyrz82xfUIn5ZrnSHQQsd6jebQ==
+
+"@esbuild/freebsd-x64@0.20.0":
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.20.0.tgz#3f9ce53344af2f08d178551cd475629147324a83"
+  integrity sha512-uG8B0WSepMRsBNVXAQcHf9+Ko/Tr+XqmK7Ptel9HVmnykupXdS4J7ovSQUIi0tQGIndhbqWLaIL/qO/cWhXKyQ==
+
+"@esbuild/linux-arm64@0.20.0":
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.20.0.tgz#24efa685515689df4ecbc13031fa0a9dda910a11"
+  integrity sha512-uTtyYAP5veqi2z9b6Gr0NUoNv9F/rOzI8tOD5jKcCvRUn7T60Bb+42NDBCWNhMjkQzI0qqwXkQGo1SY41G52nw==
+
+"@esbuild/linux-arm@0.20.0":
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.20.0.tgz#6b586a488e02e9b073a75a957f2952b3b6e87b4c"
+  integrity sha512-2ezuhdiZw8vuHf1HKSf4TIk80naTbP9At7sOqZmdVwvvMyuoDiZB49YZKLsLOfKIr77+I40dWpHVeY5JHpIEIg==
+
+"@esbuild/linux-ia32@0.20.0":
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.20.0.tgz#84ce7864f762708dcebc1b123898a397dea13624"
+  integrity sha512-c88wwtfs8tTffPaoJ+SQn3y+lKtgTzyjkD8NgsyCtCmtoIC8RDL7PrJU05an/e9VuAke6eJqGkoMhJK1RY6z4w==
+
+"@esbuild/linux-loong64@0.20.0":
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.20.0.tgz#1922f571f4cae1958e3ad29439c563f7d4fd9037"
+  integrity sha512-lR2rr/128/6svngnVta6JN4gxSXle/yZEZL3o4XZ6esOqhyR4wsKyfu6qXAL04S4S5CgGfG+GYZnjFd4YiG3Aw==
+
+"@esbuild/linux-mips64el@0.20.0":
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.20.0.tgz#7ca1bd9df3f874d18dbf46af009aebdb881188fe"
+  integrity sha512-9Sycc+1uUsDnJCelDf6ZNqgZQoK1mJvFtqf2MUz4ujTxGhvCWw+4chYfDLPepMEvVL9PDwn6HrXad5yOrNzIsQ==
+
+"@esbuild/linux-ppc64@0.20.0":
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.20.0.tgz#8f95baf05f9486343bceeb683703875d698708a4"
+  integrity sha512-CoWSaaAXOZd+CjbUTdXIJE/t7Oz+4g90A3VBCHLbfuc5yUQU/nFDLOzQsN0cdxgXd97lYW/psIIBdjzQIwTBGw==
+
+"@esbuild/linux-riscv64@0.20.0":
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.20.0.tgz#ca63b921d5fe315e28610deb0c195e79b1a262ca"
+  integrity sha512-mlb1hg/eYRJUpv8h/x+4ShgoNLL8wgZ64SUr26KwglTYnwAWjkhR2GpoKftDbPOCnodA9t4Y/b68H4J9XmmPzA==
+
+"@esbuild/linux-s390x@0.20.0":
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.20.0.tgz#cb3d069f47dc202f785c997175f2307531371ef8"
+  integrity sha512-fgf9ubb53xSnOBqyvWEY6ukBNRl1mVX1srPNu06B6mNsNK20JfH6xV6jECzrQ69/VMiTLvHMicQR/PgTOgqJUQ==
+
+"@esbuild/linux-x64@0.20.0":
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.20.0.tgz#ac617e0dc14e9758d3d7efd70288c14122557dc7"
+  integrity sha512-H9Eu6MGse++204XZcYsse1yFHmRXEWgadk2N58O/xd50P9EvFMLJTQLg+lB4E1cF2xhLZU5luSWtGTb0l9UeSg==
+
+"@esbuild/netbsd-x64@0.20.0":
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.20.0.tgz#6cc778567f1513da6e08060e0aeb41f82eb0f53c"
+  integrity sha512-lCT675rTN1v8Fo+RGrE5KjSnfY0x9Og4RN7t7lVrN3vMSjy34/+3na0q7RIfWDAj0e0rCh0OL+P88lu3Rt21MQ==
+
+"@esbuild/openbsd-x64@0.20.0":
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.20.0.tgz#76848bcf76b4372574fb4d06cd0ed1fb29ec0fbe"
+  integrity sha512-HKoUGXz/TOVXKQ+67NhxyHv+aDSZf44QpWLa3I1lLvAwGq8x1k0T+e2HHSRvxWhfJrFxaaqre1+YyzQ99KixoA==
+
+"@esbuild/sunos-x64@0.20.0":
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.20.0.tgz#ea4cd0639bf294ad51bc08ffbb2dac297e9b4706"
+  integrity sha512-GDwAqgHQm1mVoPppGsoq4WJwT3vhnz/2N62CzhvApFD1eJyTroob30FPpOZabN+FgCjhG+AgcZyOPIkR8dfD7g==
+
+"@esbuild/win32-arm64@0.20.0":
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.20.0.tgz#a5c171e4a7f7e4e8be0e9947a65812c1535a7cf0"
+  integrity sha512-0vYsP8aC4TvMlOQYozoksiaxjlvUcQrac+muDqj1Fxy6jh9l9CZJzj7zmh8JGfiV49cYLTorFLxg7593pGldwQ==
+
+"@esbuild/win32-ia32@0.20.0":
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.20.0.tgz#f8ac5650c412d33ea62d7551e0caf82da52b7f85"
+  integrity sha512-p98u4rIgfh4gdpV00IqknBD5pC84LCub+4a3MO+zjqvU5MVXOc3hqR2UgT2jI2nh3h8s9EQxmOsVI3tyzv1iFg==
+
+"@esbuild/win32-x64@0.20.0":
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.20.0.tgz#2efddf82828aac85e64cef62482af61c29561bee"
+  integrity sha512-NgJnesu1RtWihtTtXGFMU5YSE6JyyHPMxCwBZK7a6/8d31GuSo9l0Ss7w1Jw5QnKUawG6UEehs883kcXf5fYwg==
+
 "@floating-ui/core@^1.3.1", "@floating-ui/core@^1.5.3":
   version "1.5.3"
   resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.5.3.tgz#b6aa0827708d70971c8679a16cf680a515b8a52a"
@@ -2584,113 +2699,34 @@ es6-error@^4.1.1:
   resolved "https://registry.yarnpkg.com/es6-error/-/es6-error-4.1.1.tgz#9e3af407459deed47e9a91f9b885a84eb05c561d"
   integrity sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==
 
-esbuild-android-arm64@0.13.15:
-  version "0.13.15"
-  resolved "https://registry.yarnpkg.com/esbuild-android-arm64/-/esbuild-android-arm64-0.13.15.tgz#3fc3ff0bab76fe35dd237476b5d2b32bb20a3d44"
-  integrity sha512-m602nft/XXeO8YQPUDVoHfjyRVPdPgjyyXOxZ44MK/agewFFkPa8tUo6lAzSWh5Ui5PB4KR9UIFTSBKh/RrCmg==
-
-esbuild-darwin-64@0.13.15:
-  version "0.13.15"
-  resolved "https://registry.yarnpkg.com/esbuild-darwin-64/-/esbuild-darwin-64-0.13.15.tgz#8e9169c16baf444eacec60d09b24d11b255a8e72"
-  integrity sha512-ihOQRGs2yyp7t5bArCwnvn2Atr6X4axqPpEdCFPVp7iUj4cVSdisgvEKdNR7yH3JDjW6aQDw40iQFoTqejqxvQ==
-
-esbuild-darwin-arm64@0.13.15:
-  version "0.13.15"
-  resolved "https://registry.yarnpkg.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.13.15.tgz#1b07f893b632114f805e188ddfca41b2b778229a"
-  integrity sha512-i1FZssTVxUqNlJ6cBTj5YQj4imWy3m49RZRnHhLpefFIh0To05ow9DTrXROTE1urGTQCloFUXTX8QfGJy1P8dQ==
-
-esbuild-freebsd-64@0.13.15:
-  version "0.13.15"
-  resolved "https://registry.yarnpkg.com/esbuild-freebsd-64/-/esbuild-freebsd-64-0.13.15.tgz#0b8b7eca1690c8ec94c75680c38c07269c1f4a85"
-  integrity sha512-G3dLBXUI6lC6Z09/x+WtXBXbOYQZ0E8TDBqvn7aMaOCzryJs8LyVXKY4CPnHFXZAbSwkCbqiPuSQ1+HhrNk7EA==
-
-esbuild-freebsd-arm64@0.13.15:
-  version "0.13.15"
-  resolved "https://registry.yarnpkg.com/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.13.15.tgz#2e1a6c696bfdcd20a99578b76350b41db1934e52"
-  integrity sha512-KJx0fzEDf1uhNOZQStV4ujg30WlnwqUASaGSFPhznLM/bbheu9HhqZ6mJJZM32lkyfGJikw0jg7v3S0oAvtvQQ==
-
-esbuild-linux-32@0.13.15:
-  version "0.13.15"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-32/-/esbuild-linux-32-0.13.15.tgz#6fd39f36fc66dd45b6b5f515728c7bbebc342a69"
-  integrity sha512-ZvTBPk0YWCLMCXiFmD5EUtB30zIPvC5Itxz0mdTu/xZBbbHJftQgLWY49wEPSn2T/TxahYCRDWun5smRa0Tu+g==
-
-esbuild-linux-64@0.13.15:
-  version "0.13.15"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-64/-/esbuild-linux-64-0.13.15.tgz#9cb8e4bcd7574e67946e4ee5f1f1e12386bb6dd3"
-  integrity sha512-eCKzkNSLywNeQTRBxJRQ0jxRCl2YWdMB3+PkWFo2BBQYC5mISLIVIjThNtn6HUNqua1pnvgP5xX0nHbZbPj5oA==
-
-esbuild-linux-arm64@0.13.15:
-  version "0.13.15"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-arm64/-/esbuild-linux-arm64-0.13.15.tgz#3891aa3704ec579a1b92d2a586122e5b6a2bfba1"
-  integrity sha512-bYpuUlN6qYU9slzr/ltyLTR9YTBS7qUDymO8SV7kjeNext61OdmqFAzuVZom+OLW1HPHseBfJ/JfdSlx8oTUoA==
-
-esbuild-linux-arm@0.13.15:
-  version "0.13.15"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-arm/-/esbuild-linux-arm-0.13.15.tgz#8a00e99e6a0c6c9a6b7f334841364d8a2b4aecfe"
-  integrity sha512-wUHttDi/ol0tD8ZgUMDH8Ef7IbDX+/UsWJOXaAyTdkT7Yy9ZBqPg8bgB/Dn3CZ9SBpNieozrPRHm0BGww7W/jA==
-
-esbuild-linux-mips64le@0.13.15:
-  version "0.13.15"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.13.15.tgz#36b07cc47c3d21e48db3bb1f4d9ef8f46aead4f7"
-  integrity sha512-KlVjIG828uFPyJkO/8gKwy9RbXhCEUeFsCGOJBepUlpa7G8/SeZgncUEz/tOOUJTcWMTmFMtdd3GElGyAtbSWg==
-
-esbuild-linux-ppc64le@0.13.15:
-  version "0.13.15"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.13.15.tgz#f7e6bba40b9a11eb9dcae5b01550ea04670edad2"
-  integrity sha512-h6gYF+OsaqEuBjeesTBtUPw0bmiDu7eAeuc2OEH9S6mV9/jPhPdhOWzdeshb0BskRZxPhxPOjqZ+/OqLcxQwEQ==
-
-esbuild-netbsd-64@0.13.15:
-  version "0.13.15"
-  resolved "https://registry.yarnpkg.com/esbuild-netbsd-64/-/esbuild-netbsd-64-0.13.15.tgz#a2fedc549c2b629d580a732d840712b08d440038"
-  integrity sha512-3+yE9emwoevLMyvu+iR3rsa+Xwhie7ZEHMGDQ6dkqP/ndFzRHkobHUKTe+NCApSqG5ce2z4rFu+NX/UHnxlh3w==
-
-esbuild-openbsd-64@0.13.15:
-  version "0.13.15"
-  resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.13.15.tgz#b22c0e5806d3a1fbf0325872037f885306b05cd7"
-  integrity sha512-wTfvtwYJYAFL1fSs8yHIdf5GEE4NkbtbXtjLWjM3Cw8mmQKqsg8kTiqJ9NJQe5NX/5Qlo7Xd9r1yKMMkHllp5g==
-
-esbuild-sunos-64@0.13.15:
-  version "0.13.15"
-  resolved "https://registry.yarnpkg.com/esbuild-sunos-64/-/esbuild-sunos-64-0.13.15.tgz#d0b6454a88375ee8d3964daeff55c85c91c7cef4"
-  integrity sha512-lbivT9Bx3t1iWWrSnGyBP9ODriEvWDRiweAs69vI+miJoeKwHWOComSRukttbuzjZ8r1q0mQJ8Z7yUsDJ3hKdw==
-
-esbuild-windows-32@0.13.15:
-  version "0.13.15"
-  resolved "https://registry.yarnpkg.com/esbuild-windows-32/-/esbuild-windows-32-0.13.15.tgz#c96d0b9bbb52f3303322582ef8e4847c5ad375a7"
-  integrity sha512-fDMEf2g3SsJ599MBr50cY5ve5lP1wyVwTe6aLJsM01KtxyKkB4UT+fc5MXQFn3RLrAIAZOG+tHC+yXObpSn7Nw==
-
-esbuild-windows-64@0.13.15:
-  version "0.13.15"
-  resolved "https://registry.yarnpkg.com/esbuild-windows-64/-/esbuild-windows-64-0.13.15.tgz#1f79cb9b1e1bb02fb25cd414cb90d4ea2892c294"
-  integrity sha512-9aMsPRGDWCd3bGjUIKG/ZOJPKsiztlxl/Q3C1XDswO6eNX/Jtwu4M+jb6YDH9hRSUflQWX0XKAfWzgy5Wk54JQ==
-
-esbuild-windows-arm64@0.13.15:
-  version "0.13.15"
-  resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.13.15.tgz#482173070810df22a752c686509c370c3be3b3c3"
-  integrity sha512-zzvyCVVpbwQQATaf3IG8mu1IwGEiDxKkYUdA4FpoCHi1KtPa13jeScYDjlW0Qh+ebWzpKfR2ZwvqAQkSWNcKjA==
-
-esbuild@^0.13.8:
-  version "0.13.15"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.13.15.tgz#db56a88166ee373f87dbb2d8798ff449e0450cdf"
-  integrity sha512-raCxt02HBKv8RJxE8vkTSCXGIyKHdEdGfUmiYb8wnabnaEmHzyW7DCHb5tEN0xU8ryqg5xw54mcwnYkC4x3AIw==
+esbuild@^0.20.0:
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.20.0.tgz#a7170b63447286cd2ff1f01579f09970e6965da4"
+  integrity sha512-6iwE3Y2RVYCME1jLpBqq7LQWK3MW6vjV2bZy6gt/WrqkY+WE74Spyc0ThAOYpMtITvnjX09CrC6ym7A/m9mebA==
   optionalDependencies:
-    esbuild-android-arm64 "0.13.15"
-    esbuild-darwin-64 "0.13.15"
-    esbuild-darwin-arm64 "0.13.15"
-    esbuild-freebsd-64 "0.13.15"
-    esbuild-freebsd-arm64 "0.13.15"
-    esbuild-linux-32 "0.13.15"
-    esbuild-linux-64 "0.13.15"
-    esbuild-linux-arm "0.13.15"
-    esbuild-linux-arm64 "0.13.15"
-    esbuild-linux-mips64le "0.13.15"
-    esbuild-linux-ppc64le "0.13.15"
-    esbuild-netbsd-64 "0.13.15"
-    esbuild-openbsd-64 "0.13.15"
-    esbuild-sunos-64 "0.13.15"
-    esbuild-windows-32 "0.13.15"
-    esbuild-windows-64 "0.13.15"
-    esbuild-windows-arm64 "0.13.15"
+    "@esbuild/aix-ppc64" "0.20.0"
+    "@esbuild/android-arm" "0.20.0"
+    "@esbuild/android-arm64" "0.20.0"
+    "@esbuild/android-x64" "0.20.0"
+    "@esbuild/darwin-arm64" "0.20.0"
+    "@esbuild/darwin-x64" "0.20.0"
+    "@esbuild/freebsd-arm64" "0.20.0"
+    "@esbuild/freebsd-x64" "0.20.0"
+    "@esbuild/linux-arm" "0.20.0"
+    "@esbuild/linux-arm64" "0.20.0"
+    "@esbuild/linux-ia32" "0.20.0"
+    "@esbuild/linux-loong64" "0.20.0"
+    "@esbuild/linux-mips64el" "0.20.0"
+    "@esbuild/linux-ppc64" "0.20.0"
+    "@esbuild/linux-riscv64" "0.20.0"
+    "@esbuild/linux-s390x" "0.20.0"
+    "@esbuild/linux-x64" "0.20.0"
+    "@esbuild/netbsd-x64" "0.20.0"
+    "@esbuild/openbsd-x64" "0.20.0"
+    "@esbuild/sunos-x64" "0.20.0"
+    "@esbuild/win32-arm64" "0.20.0"
+    "@esbuild/win32-ia32" "0.20.0"
+    "@esbuild/win32-x64" "0.20.0"
 
 escalade@^3.1.1:
   version "3.1.1"


### PR DESCRIPTION
- upgrades esbuild to latest version, as part of core dependencies review
- incorporate lint into build step, and prefer `yarn run build` to calling `./build.sh` directly 
- update README and some documentation (comments)

Had to refactor the prior esbuild callbacks to [plugins](https://esbuild.github.io/plugins/), which was easy enough once I figured out what to look for. The build itself is a bit slower, but still acceptable. Definitely a few improvements left on the table:

* Renderer code should use a live or hot reload server, instead of re-starting the electron process
* Type checking could be more thoroughly integrated (fail the bundle), and faster (incremental? stateful process?)

Overall probably worth looking into third party libraries that have likely sorted this out well; now that the project is on the latest esbuild version that should be easier. 

Likely the last batch of work I'll do as part of #118 