### PR TITLE
add local video support

### DIFF
--- a/src/hooks/images.tsx
+++ b/src/hooks/images.tsx
@@ -194,7 +194,7 @@ const imageExtensions = [
 ];
 
 // https://github.com/sindresorhus/video-extensions/blob/main/video-extensions.json
-const videoExtensions = [
+export const videoExtensions = [
   "3g2",
   "3gp",
   "aaf",

--- a/src/index.html
+++ b/src/index.html
@@ -6,7 +6,7 @@
     <link href="renderer.bundle.css" rel="stylesheet" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self' 'unsafe-inline'; img-src chronicles://* https://* data:; style-src 'self' fonts.googleapis.com 'unsafe-inline'; font-src fonts.gstatic.com"
+      content="default-src 'self' 'unsafe-inline'; media-src chronicles://* https://*; img-src chronicles://* https://* data:; style-src 'self' fonts.googleapis.com 'unsafe-inline'; font-src fonts.gstatic.com"
     />
   </head>
 

--- a/src/markdown/remark-slate-transformer/models/mdast.ts
+++ b/src/markdown/remark-slate-transformer/models/mdast.ts
@@ -122,8 +122,9 @@ export interface Link extends Parent, Resource {
   children: StaticPhrasingContent[];
 }
 
-export interface Image extends Resource, Alternative {
+export interface Image extends Resource {
   type: "image";
+  alt?: string;
 }
 
 export interface LinkReference extends Parent, Reference {
@@ -131,8 +132,9 @@ export interface LinkReference extends Parent, Reference {
   children: StaticPhrasingContent[];
 }
 
-export interface ImageReference extends Reference, Alternative {
+export interface ImageReference extends Reference {
   type: "imageReference";
+  alt?: string;
 }
 
 export interface Footnote extends Parent {
@@ -164,10 +166,6 @@ export interface Association {
 
 export interface Reference extends Association {
   referenceType: ReferenceType;
-}
-
-export interface Alternative {
-  alt?: string;
 }
 
 export type Content =

--- a/src/markdown/remark-slate-transformer/transformers/slate-to-mdast.ts
+++ b/src/markdown/remark-slate-transformer/transformers/slate-to-mdast.ts
@@ -1,7 +1,7 @@
 import * as unistLib from "unist";
 import * as slate from "../models/slate";
 import * as mdast from "../models/mdast";
-import * as slateInternal from "./mdast-to-slate";
+import * as SlateNodes from "./mdast-to-slate";
 
 import { Node as SNode } from "slate";
 
@@ -58,9 +58,9 @@ function createMdastRoot(node: slate.Node): unistLib.Node {
 
 function convertNodes(nodes: slate.Node[]): unistLib.Node[] {
   const mdastNodes: unistLib.Node[] = [];
-  let textQueue: slateInternal.Text[] = [];
+  let textQueue: SlateNodes.Text[] = [];
   for (let i = 0; i <= nodes.length; i++) {
-    const n = nodes[i] as slateInternal.SlateNode;
+    const n = nodes[i] as SlateNodes.SlateNode;
     if (n && isText(n)) {
       textQueue.push(n);
     } else {
@@ -234,6 +234,7 @@ function createMdastNode(
     case "image":
     // NOTE: I MODIFIED next line to also catch img as image
     case "img":
+    case "video":
       return createImage(node);
     case "linkReference":
       return createLinkReference(node);
@@ -248,7 +249,11 @@ function createMdastNode(
     case "inlineMath":
       return createInlineMath(node);
     default:
-      console.warn("slateToMdast encountered unknown node type", node);
+      console.warn(
+        "slateToMdast encountered unknown node type:",
+        node,
+        "If this is a custom node, it will not be converted to markdown (and likely not-persisted)",
+      );
       // @ts-ignore
       const _: never = node;
       break;
@@ -256,7 +261,7 @@ function createMdastNode(
   return null;
 }
 
-function isText(node: slateInternal.SlateNode): node is slateInternal.Text {
+function isText(node: SlateNodes.SlateNode): node is SlateNodes.Text {
   return "text" in node;
 }
 
@@ -284,7 +289,7 @@ function mergeTexts(nodes: TextOrDecoration[]): TextOrDecoration[] {
   return res;
 }
 
-function createParagraph(node: slateInternal.Paragraph): mdast.Paragraph {
+function createParagraph(node: SlateNodes.Paragraph): mdast.Paragraph {
   const { type, children } = node;
   return {
     type: "paragraph",
@@ -292,7 +297,7 @@ function createParagraph(node: slateInternal.Paragraph): mdast.Paragraph {
   };
 }
 
-function createHeading(node: slateInternal.Heading): mdast.Heading {
+function createHeading(node: SlateNodes.Heading): mdast.Heading {
   const { type, depth, children } = node;
   return {
     type: "heading",
@@ -304,7 +309,7 @@ function createHeading(node: slateInternal.Heading): mdast.Heading {
 }
 
 function createThematicBreak(
-  node: slateInternal.ThematicBreak,
+  node: SlateNodes.ThematicBreak,
 ): mdast.ThematicBreak {
   const { type } = node;
   return {
@@ -312,7 +317,7 @@ function createThematicBreak(
   };
 }
 
-function createBlockquote(node: slateInternal.Blockquote): mdast.Blockquote {
+function createBlockquote(node: SlateNodes.Blockquote): mdast.Blockquote {
   const { type, children } = node;
   return {
     type,
@@ -320,7 +325,7 @@ function createBlockquote(node: slateInternal.Blockquote): mdast.Blockquote {
   };
 }
 
-function createList(node: slateInternal.List): mdast.List {
+function createList(node: SlateNodes.List): mdast.List {
   const { type, ordered, start, spread, children } = node;
   return {
     type: "list",
@@ -331,7 +336,7 @@ function createList(node: slateInternal.List): mdast.List {
   };
 }
 
-function createListItem(node: slateInternal.ListItem): mdast.ListItem {
+function createListItem(node: SlateNodes.ListItem): mdast.ListItem {
   const { type, checked, spread, children } = node;
   return {
     type: "listItem",
@@ -341,7 +346,7 @@ function createListItem(node: slateInternal.ListItem): mdast.ListItem {
   };
 }
 
-function createTable(node: slateInternal.Table): mdast.Table {
+function createTable(node: SlateNodes.Table): mdast.Table {
   const { type, align, children } = node;
   return {
     type,
@@ -350,7 +355,7 @@ function createTable(node: slateInternal.Table): mdast.Table {
   };
 }
 
-function createTableRow(node: slateInternal.TableRow): mdast.TableRow {
+function createTableRow(node: SlateNodes.TableRow): mdast.TableRow {
   const { type, children } = node;
   return {
     type,
@@ -358,7 +363,7 @@ function createTableRow(node: slateInternal.TableRow): mdast.TableRow {
   };
 }
 
-function createTableCell(node: slateInternal.TableCell): mdast.TableCell {
+function createTableCell(node: SlateNodes.TableCell): mdast.TableCell {
   const { type, children } = node;
   return {
     type,
@@ -366,7 +371,7 @@ function createTableCell(node: slateInternal.TableCell): mdast.TableCell {
   };
 }
 
-function createHtml(node: slateInternal.Html): mdast.HTML {
+function createHtml(node: SlateNodes.Html): mdast.HTML {
   const { type, children } = node;
   return {
     type,
@@ -374,7 +379,7 @@ function createHtml(node: slateInternal.Html): mdast.HTML {
   };
 }
 
-function createCode(node: slateInternal.Code): mdast.Code {
+function createCode(node: SlateNodes.Code): mdast.Code {
   const { lang, meta } = node;
 
   // The slateInternal.Code type says its children are text nodes. However the
@@ -396,7 +401,7 @@ function createCode(node: slateInternal.Code): mdast.Code {
   };
 }
 
-function createYaml(node: slateInternal.Yaml): mdast.YAML {
+function createYaml(node: SlateNodes.Yaml): mdast.YAML {
   const { type, children } = node;
   return {
     type,
@@ -404,7 +409,7 @@ function createYaml(node: slateInternal.Yaml): mdast.YAML {
   };
 }
 
-function createToml(node: slateInternal.Toml): mdast.TOML {
+function createToml(node: SlateNodes.Toml): mdast.TOML {
   const { type, children } = node;
   return {
     type,
@@ -412,7 +417,7 @@ function createToml(node: slateInternal.Toml): mdast.TOML {
   };
 }
 
-function createDefinition(node: slateInternal.Definition): mdast.Definition {
+function createDefinition(node: SlateNodes.Definition): mdast.Definition {
   const { type, identifier, label, url, title } = node;
   return {
     type,
@@ -424,7 +429,7 @@ function createDefinition(node: slateInternal.Definition): mdast.Definition {
 }
 
 function createFootnoteDefinition(
-  node: slateInternal.FootnoteDefinition,
+  node: SlateNodes.FootnoteDefinition,
 ): mdast.FootnoteDefinition {
   const { type, identifier, label, children } = node;
   return {
@@ -437,14 +442,14 @@ function createFootnoteDefinition(
   };
 }
 
-function createBreak(node: slateInternal.Break): mdast.Break {
+function createBreak(node: SlateNodes.Break): mdast.Break {
   const { type } = node;
   return {
     type,
   };
 }
 
-function createLink(node: slateInternal.Link): mdast.Link {
+function createLink(node: SlateNodes.Link): mdast.Link {
   const { type, url, title, children } = node;
   return {
     type: "link", // note: changes from type to type: "link" so it can accept "a", see the switch statement
@@ -454,15 +459,21 @@ function createLink(node: slateInternal.Link): mdast.Link {
   } as any;
 }
 
-function createImage(node: slateInternal.Image | any): mdast.Image {
+function createImage(node: SlateNodes.Image | SlateNodes.Video): mdast.Image {
   const { type, url, title, alt } = node;
   return {
-    // NOTE: added this @ts-ignore line
-    // todo: replace "image" with a constant, like mdast.Image.type
-    // @ts-ignore
-    type: "image", // NOTE: added here because createImage may be called with type: 'img" -- convert to something mdast understands
+    // 1. Slate image may have type: "img" -- convert to something mdast understands
+    // 2. I piggy back on image elements to handle video; incoming node my be video,
+    // but store in markdown as an image (i.e. ![my cool video](some-video.mp4))
+    // Requires the mdast-to-slate image transformer to reverse this
+    type: "image",
     url: unPrefixUrl(url),
     title,
+
+    // The actual alt property is a string, but its some hard-coded placeholder
+    // "Here is a caption!". The caption you actually write, is stored in
+    // { node: { caption: { text: 'What you wrote is here' }}}
+    // Probably this is controlled by CaptionElement + createCaptionPlugin
     alt: node.caption
       ? node.caption.map((c: any) => SNode.string(c)).join("\n")
       : undefined,
@@ -470,7 +481,7 @@ function createImage(node: slateInternal.Image | any): mdast.Image {
 }
 
 function createLinkReference(
-  node: slateInternal.LinkReference,
+  node: SlateNodes.LinkReference,
 ): mdast.LinkReference {
   const { type, identifier, label, referenceType, children } = node;
   return {
@@ -483,7 +494,7 @@ function createLinkReference(
 }
 
 function createImageReference(
-  node: slateInternal.ImageReference,
+  node: SlateNodes.ImageReference,
 ): mdast.ImageReference {
   const { type, identifier, label, alt, referenceType } = node;
   return {
@@ -495,7 +506,7 @@ function createImageReference(
   };
 }
 
-function createFootnote(node: slateInternal.Footnote): mdast.Footnote {
+function createFootnote(node: SlateNodes.Footnote): mdast.Footnote {
   const { type, children } = node;
   return {
     type,
@@ -504,7 +515,7 @@ function createFootnote(node: slateInternal.Footnote): mdast.Footnote {
 }
 
 function creatFootnoteReference(
-  node: slateInternal.FootnoteReference,
+  node: SlateNodes.FootnoteReference,
 ): mdast.FootnoteReference {
   const { type, identifier, label } = node;
   return {
@@ -514,7 +525,7 @@ function creatFootnoteReference(
   };
 }
 
-function createMath(node: slateInternal.Math): mdast.Math {
+function createMath(node: SlateNodes.Math): mdast.Math {
   const { type, children } = node;
   return {
     type,
@@ -522,7 +533,7 @@ function createMath(node: slateInternal.Math): mdast.Math {
   };
 }
 
-function createInlineMath(node: slateInternal.InlineMath): mdast.InlineMath {
+function createInlineMath(node: SlateNodes.InlineMath): mdast.InlineMath {
   const { type, children } = node;
   return {
     type,

--- a/src/preload/client/files.ts
+++ b/src/preload/client/files.ts
@@ -88,4 +88,23 @@ export class FilesClient {
       });
     });
   };
+
+  uploadFile = async (file: File): Promise<UploadResponse> => {
+    const dir = await this.settings.get("USER_FILES_DIR");
+    const ext = path.parse(file.name).ext;
+    const filename = `${uuidv7()}${ext || ".unknown"}`;
+    const filepath = path.join(dir as string, filename);
+    return new Promise<UploadResponse>((res, rej) => {
+      const stream = fs.createWriteStream(filepath);
+      // the fs write stream is not compatible with the input stream :(
+      // file.stream().pipeTo(stream);
+
+      // Normally, .path is not available in browsers. But in electron, it is.
+      const inStream = fs.createReadStream((file as any).path);
+      inStream
+        .pipe(stream)
+        .on("close", () => res({ filename: filename }))
+        .on("error", (err) => rej(err));
+    });
+  };
 }

--- a/src/views/edit/editor/elements/Video.tsx
+++ b/src/views/edit/editor/elements/Video.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { PlateRenderElementProps, PlateElement } from "@udecode/plate";
+import { Caption, CaptionTextarea } from "./Caption";
+import { MediaPopover } from "./MediaPopover";
+import { ELEMENT_VIDEO } from "../plugins/createVideoPlugin";
+
+/**
+ * Renders <video> elements. Expects a url to be present in the element.
+ */
+export const VideoElement = ({
+  className,
+  children,
+  nodeProps,
+  ...props
+}: PlateRenderElementProps) => {
+  return (
+    <MediaPopover pluginKey={ELEMENT_VIDEO}>
+      <PlateElement asChild className={className} {...props}>
+        <figure className="group relative m-0" contentEditable={false}>
+          <video
+            src={props.element.url as any}
+            controls
+            style={{
+              display: "block",
+              maxWidth: "80%",
+              maxHeight: "20em",
+              margin: "auto", // center
+            }}
+          >
+            Unable to load video.
+          </video>
+          <Caption align="center">
+            <CaptionTextarea placeholder="Write a caption..." />
+          </Caption>
+          {children}
+        </figure>
+      </PlateElement>
+    </MediaPopover>
+  );
+};

--- a/src/views/edit/editor/elements/index.tsx
+++ b/src/views/edit/editor/elements/index.tsx
@@ -9,3 +9,4 @@ export * from "./Link";
 export * from "./List";
 export * from "./ImageElement";
 export * from "./LinkFloatingToolbar";
+export * from "./Video";

--- a/src/views/edit/editor/index.tsx
+++ b/src/views/edit/editor/index.tsx
@@ -78,7 +78,10 @@ import {
   LinkElement,
   ListElement,
   LinkFloatingToolbar,
+  VideoElement,
 } from "./elements";
+
+import { ELEMENT_VIDEO, createVideoPlugin } from "./plugins/createVideoPlugin";
 
 import { uploadImage } from "../../../hooks/images";
 
@@ -121,7 +124,14 @@ export default observer((props: Props) => {
           uploadImage: uploadImage,
         },
       }),
-      createMediaEmbedPlugin(),
+
+      // Plate's media handler turns youtube links, twitter links, etc, into embeds.
+      // I'm unsure how to trigger the logic, probabzly via toolbar or shortcut.
+      // createMediaEmbedPlugin(),
+
+      // NOTE: This plugin MUST come after createImagePlugin, otherwise createImagePlugin swallows
+      // dropped video files and this won't be called.
+      createVideoPlugin(),
 
       // I believe this is so hitting backspace lets you select and delete the
       // image
@@ -235,13 +245,13 @@ export default observer((props: Props) => {
           },
         },
       }),
-      createIndentListPlugin(),
 
-      //
+      createIndentListPlugin(),
       createTrailingBlockPlugin({ type: ELEMENT_PARAGRAPH }),
     ],
     {
       components: {
+        [ELEMENT_VIDEO]: VideoElement,
         [ELEMENT_BLOCKQUOTE]: BlockquoteElement,
         [ELEMENT_CODE_BLOCK]: CodeLeaf, // todo: should be a code block
         // [ELEMENT_HR]: HrElement,

--- a/src/views/edit/editor/plugins/createVideoPlugin.tsx
+++ b/src/views/edit/editor/plugins/createVideoPlugin.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import {
+  PlateEditor,
+  PlateRenderElementProps,
+  PlateElement,
+  WithPlatePlugin,
+  createPluginFactory,
+  insertNode,
+} from "@udecode/plate";
+import { videoExtensions } from "../../../../hooks/images";
+// Ideally this is injected
+import { IClient } from "../../../../hooks/useClient";
+
+const client: IClient = (window as any).chronicles.createClient();
+
+export const ELEMENT_VIDEO = "video";
+
+/**
+ * createVideoPlugin handles copying drag and dropped video files, then injecting
+ * a video element with a reference to its copied url.
+ */
+export const createVideoPlugin = createPluginFactory({
+  key: ELEMENT_VIDEO,
+
+  // https://docs.slatejs.org/concepts/02-nodes
+  isElement: true,
+
+  // Means: This element is not editable.
+  isVoid: true,
+
+  withOverrides: (editor: PlateEditor, _: WithPlatePlugin) => {
+    // store reference to original insertData function; we'll call it later
+    const insertData = editor.insertData;
+
+    // override insertData function to handle video files
+    editor.insertData = (dataTransfer: DataTransfer) => {
+      const text = dataTransfer.getData("text/plain");
+      const { files } = dataTransfer;
+
+      // note: !text copied from createImagePlugin; I'm unsure if it's necessary.
+      if (!text && files && files.length > 0) {
+        for (const file of files) {
+          const [mime] = file.type.split("/");
+          const extension = (file.name.split(".").pop() || "").toLowerCase();
+
+          if (mime == "video") {
+            // The slate-mdast parser / serializer relies on a whitelist of
+            // extensions to parse and serialize the video element correctly.
+            if (!videoExtensions.includes(extension || "")) {
+              console.error("Unsupported video extension:", extension);
+              continue;
+            }
+
+            client.files.uploadFile(file).then((json: any) => {
+              // TODO: The structure of the inserted node follows that of Image nodes. Slate / Plate have a
+              // schema somewhere (normalization?), and deviating from it here results in SILENT FAILURE.
+              // Figure out the proper place to document and type valid nodes; discovering this behavior
+              // was hell.
+              insertNode(editor, {
+                type: ELEMENT_VIDEO,
+                url: `chronicles://${json.filename}`,
+                children: [{ text: "" }],
+              });
+            });
+          } else {
+            // If it's not a video, delegate to the next plugin.
+            insertData(dataTransfer);
+          }
+        }
+      } else {
+        // If it's not a file, delegate to the next plugin.
+        insertData(dataTransfer);
+      }
+    };
+
+    return editor;
+  },
+});


### PR DESCRIPTION
- support drag and dropping local video files. Video files are uploaded then displayed inline
- parse and serialize video elements in markdown using image syntax

Video files are stored in markdown as images: `![my cool video](my-cool-video.mov)`. When parsing (markdown -> mdast -> slate), the markdown parser checks image tags for extensions, and when found, creates a video Slate node instead of an image node:

```
{
  type: 'video'
  url: 'chronicles://my-cool-video.mov'
  // ...
}
```

To render, the added `VideoElement` is included into the Plate components list; the implementation is naive. (On second pass, I added Captioning and media toolbar for delete).

<img width="715" alt="Screenshot 2024-02-05 at 8 43 57 AM" src="https://github.com/cloverich/chronicles/assets/1010084/db69420b-7b2b-4108-9e43-efd02a658f7a">



Closes #54 