### PR TITLE
add document tagging

### DIFF
--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -96,6 +96,7 @@ async function watchRenderer() {
     bundle: true,
     platform: "browser",
     plugins: [startElectronPlugin("renderer")],
+    sourcemap: true,
   });
 
   await ctxRenderer.watch();
@@ -109,6 +110,7 @@ async function watchPreload() {
     platform: "node",
     external: ["knex", "electron", "electron-store", "better-sqlite3"],
     plugins: [startElectronPlugin("preload")],
+    sourcemap: true,
   });
 
   await ctxPreload.watch();

--- a/src/electron/migrations/20211005142122.sql
+++ b/src/electron/migrations/20211005142122.sql
@@ -30,11 +30,17 @@ CREATE TABLE  IF NOT EXISTS "documents" (
     FOREIGN KEY ("journalId") REFERENCES "journals" ("id") ON DELETE CASCADE ON UPDATE CASCADE
 );
 
--- CreateIndex
+
+-- CreateTable
+CREATE TABLE IF NOT EXISTS "document_tags" (
+    "documentId" TEXT NOT NULL,
+    "tag" TEXT NOT NULL,
+    FOREIGN KEY ("documentId") REFERENCES "documents" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    PRIMARY KEY ("documentId", "tag")
+);
+
+
 CREATE UNIQUE INDEX  IF NOT EXISTS "journals_name_uniq" ON "journals"("name");
-
--- CreateIndex
 CREATE INDEX  IF NOT EXISTS "documents_title_idx" ON "documents"("title");
-
--- CreateIndex
 CREATE INDEX  IF NOT EXISTS "documents_createdat_idx" ON "documents"("createdAt");
+CREATE INDEX IF NOT EXISTS "tags_name_idx" ON "document_tags"("tag");

--- a/src/hooks/useTags.ts
+++ b/src/hooks/useTags.ts
@@ -1,0 +1,39 @@
+import React from "react";
+import useClient from "./useClient";
+
+/**
+ * Hook for loading tags.
+ */
+export function useTags() {
+  const [loading, setLoading] = React.useState(true);
+  const [tags, setTags] = React.useState<string[]>([]);
+  const [error, setError] = React.useState(null);
+  const client = useClient();
+
+  React.useEffect(() => {
+    let isEffectMounted = true;
+    setLoading(true);
+
+    async function load() {
+      try {
+        const tags = await client.tags.all();
+        if (!isEffectMounted) return;
+
+        setTags(tags);
+        setLoading(false);
+      } catch (err: any) {
+        if (!isEffectMounted) return;
+
+        setError(err);
+        setLoading(false);
+      }
+    }
+
+    load();
+    return () => {
+      isEffectMounted = false;
+    };
+  }, []);
+
+  return { loading, tags, error };
+}

--- a/src/markdown/index.ts
+++ b/src/markdown/index.ts
@@ -8,6 +8,20 @@ import { Node as SNode } from "slate";
 
 export * from "ts-mdast";
 
+// I usually forget how unified works, so just leaving some notes for reference
+// https://github.com/orgs/unifiedjs/discussions/113
+// | ........................ process ........................... |
+// | .......... parse ... | ... run ... | ... stringify ..........|
+//
+//           +--------+                     +----------+
+// Input ->- | Parser | ->- Syntax Tree ->- | Compiler | ->- Output
+//           +--------+          |          +----------+
+//                               X
+//                               |
+//                        +--------------+
+//                        | Transformers |
+//                        +--------------+
+
 const stringifier = unified().use(remarkStringify);
 const parser = unified().use(remarkParse).use(remarkGfm);
 

--- a/src/markdown/remark-slate-transformer/plugins/remark-to-slate.ts
+++ b/src/markdown/remark-slate-transformer/plugins/remark-to-slate.ts
@@ -1,6 +1,6 @@
 import { mdastToSlate } from "../transformers/mdast-to-slate";
 
-export default function plugin() {
+export default function remarkToSlatePlugin() {
   // @ts-ignore
   this.Compiler = function (node: any) {
     return mdastToSlate(node);

--- a/src/markdown/remark-slate-transformer/plugins/slate-to-remark.ts
+++ b/src/markdown/remark-slate-transformer/plugins/slate-to-remark.ts
@@ -3,10 +3,13 @@ import { slateToMdast } from "../transformers/slate-to-mdast";
 
 type Settings = {};
 
-const plugin: Plugin<[Settings?]> = function (settings?: Settings) {
+const slateToRemarkPlugin: Plugin<[Settings?]> = function (
+  settings?: Settings,
+) {
   // @ts-ignore
   return function (node: any) {
     return slateToMdast(node);
   };
 };
-export default plugin;
+
+export default slateToRemarkPlugin;

--- a/src/preload/client/index.ts
+++ b/src/preload/client/index.ts
@@ -1,5 +1,6 @@
 import { JournalsClient } from "./journals";
 import { DocumentsClient } from "./documents";
+import { TagsClient } from "./tags";
 import { PreferencesClient } from "./preferences";
 import { FilesClient } from "./files";
 import { IClient } from "./types";
@@ -33,6 +34,7 @@ export function create(): IClient {
     client = {
       journals: new JournalsClient(db),
       documents: new DocumentsClient(db, knex),
+      tags: new TagsClient(db, knex),
       preferences: new PreferencesClient(settings),
       files: new FilesClient(settings),
     };

--- a/src/preload/client/tags.ts
+++ b/src/preload/client/tags.ts
@@ -1,0 +1,18 @@
+import { Database } from "better-sqlite3";
+import { Knex } from "knex";
+
+export type ITagsClient = TagsClient;
+
+export class TagsClient {
+  constructor(
+    private db: Database,
+    private knex: Knex,
+  ) {}
+
+  all = async (): Promise<string[]> => {
+    return this.db
+      .prepare(`SELECT DISTINCT tag FROM document_tags`)
+      .all()
+      .map((row) => row.tag);
+  };
+}

--- a/src/preload/client/types.ts
+++ b/src/preload/client/types.ts
@@ -2,6 +2,7 @@ import { IJournalsClient } from "./journals";
 import { IDocumentsClient } from "./documents";
 import { IPreferencesClient } from "./preferences";
 import { IFilesClient } from "./files";
+import { ITagsClient } from "./tags";
 
 // This interface was created with these "I" types like this
 // so non-preload code could import this type without the bundler
@@ -9,6 +10,7 @@ import { IFilesClient } from "./files";
 // to be run in a node environment.
 export interface IClient {
   journals: IJournalsClient;
+  tags: ITagsClient;
   documents: IDocumentsClient;
   preferences: IPreferencesClient;
   files: IFilesClient;

--- a/src/preload/importer/importChronicles.ts
+++ b/src/preload/importer/importChronicles.ts
@@ -69,6 +69,7 @@ export async function importChronicles(notesDir: string) {
           updatedAt: date.toISO()!,
           content: document.content,
           title: document.title,
+          tags: [], // todo
         });
         console.log("created", doc.id);
       }

--- a/src/views/documents/Layout.tsx
+++ b/src/views/documents/Layout.tsx
@@ -1,20 +1,9 @@
-import React, { useContext } from "react";
-import {
-  Pane,
-  SideSheet,
-  Card,
-  Heading,
-  UnorderedList,
-  ListItem,
-  FolderCloseIcon,
-  IconButton,
-  FolderOpenIcon,
-} from "evergreen-ui";
-import TagSearch from "./search";
+import React from "react";
+import { Pane, IconButton, FolderOpenIcon } from "evergreen-ui";
+import SearchDocuments from "./search";
 import { Link } from "react-router-dom";
 import { SearchStore } from "./SearchStore";
-import { JournalsStoreContext } from "../../hooks/useJournalsLoader";
-import { JournalResponse } from "../../hooks/useClient";
+import { JournalSelectionSidebar } from "./Sidebar";
 
 interface Props {
   store: SearchStore;
@@ -40,7 +29,7 @@ export function Layout(props: Props) {
           setIsShown={setIsSidebarOpen}
           search={props.store}
         />
-        <TagSearch store={props.store} />
+        <SearchDocuments store={props.store} />
       </Pane>
       <Pane>
         <Link to="/documents/edit/new">Create new</Link>
@@ -50,84 +39,8 @@ export function Layout(props: Props) {
   );
 }
 
-interface SidebarProps {
+export interface SidebarProps {
   isShown: boolean;
   setIsShown: (isShown: boolean) => void;
   search: SearchStore;
-}
-
-/**
- * Sidebar for selecting journals to search.
- */
-function JournalSelectionSidebar(props: SidebarProps) {
-  const { isShown, setIsShown } = props;
-  const jstore = useContext(JournalsStoreContext);
-  const searchStore = props.search;
-
-  function search(journal: string) {
-    searchStore.setSearch([`in:${journal}`]);
-    setIsShown(false);
-    return false;
-  }
-
-  return (
-    <React.Fragment>
-      <SideSheet
-        position="left"
-        isShown={isShown}
-        onCloseComplete={() => setIsShown(false)}
-        preventBodyScrolling
-        containerProps={{
-          display: "flex",
-          flex: "1",
-          flexDirection: "column",
-        }}
-      >
-        <Pane zIndex={1} flexShrink={0} elevation={0} backgroundColor="white">
-          <Pane padding={16}>
-            <Heading size={600}>Journals</Heading>
-          </Pane>
-        </Pane>
-        <Pane flex="1" overflowY="scroll" background="tint1" padding={16}>
-          <JournalsCard
-            journals={jstore.active}
-            title="Active Journals"
-            search={search}
-          />
-          <JournalsCard
-            journals={jstore.archived}
-            title="Archived Journals"
-            search={search}
-          />
-        </Pane>
-      </SideSheet>
-    </React.Fragment>
-  );
-}
-
-function JournalsCard(props: {
-  journals: JournalResponse[];
-  title: string;
-  search: (journalName: string) => boolean;
-}) {
-  if (!props.journals.length) {
-    return null;
-  }
-
-  const journals = props.journals.map((j) => {
-    return (
-      <ListItem key={j.id} icon={FolderCloseIcon}>
-        <a href="" onClick={() => props.search(j.name)}>
-          {j.name}
-        </a>
-      </ListItem>
-    );
-  });
-
-  return (
-    <Card backgroundColor="white" elevation={0} padding={16} marginBottom={16}>
-      <Heading>{props.title}</Heading>
-      <UnorderedList>{journals}</UnorderedList>
-    </Card>
-  );
 }

--- a/src/views/documents/SearchParser.ts
+++ b/src/views/documents/SearchParser.ts
@@ -1,10 +1,11 @@
 import { SearchToken } from "./search/tokens";
-import { FocusTokenParser } from "./search/parsers/focus";
+// import { FocusTokenParser } from "./search/parsers/focus";
 import { JournalTokenParser } from "./search/parsers/in";
 import { FilterTokenParser } from "./search/parsers/filter";
 import { TitleTokenParser } from "./search/parsers/title";
 import { TextTokenParser } from "./search/parsers/text";
 import { BeforeTokenParser } from "./search/parsers/before";
+import { TagTokenParser } from "./search/parsers/tag";
 
 // TODO: This won't allow searching where value has colon in it
 const tokenRegex = /^(.*):(.*)/;
@@ -20,9 +21,10 @@ interface TokenParser<T = any> {
 // todo: Type this as <SearchToken['type'], TokenParser<SearchToken>, where the type key matches
 // a specific parser that corresponds to it.
 const parsers: Record<SearchToken["type"], TokenParser<any>> = {
-  focus: new FocusTokenParser(),
+  // focus: new FocusTokenParser(),
   in: new JournalTokenParser(),
   filter: new FilterTokenParser(),
+  tag: new TagTokenParser(),
   title: new TitleTokenParser(),
   text: new TextTokenParser(),
   before: new BeforeTokenParser(),
@@ -43,7 +45,7 @@ export class SearchParser {
    *
    * @param tokenStr - The raw string from the search input
    */
-  private parserFor<SearchToken>(
+  private parseFor<SearchToken>(
     tokenStr: string,
   ): [TokenParser<SearchToken>, SearchToken] | undefined {
     if (!tokenStr) return;
@@ -68,7 +70,7 @@ export class SearchParser {
   }
 
   parseToken = (tokenStr: string) => {
-    const results = this.parserFor(tokenStr);
+    const results = this.parseFor(tokenStr);
     if (!results) return;
 
     const [_, parsedToken] = results;
@@ -94,7 +96,7 @@ export class SearchParser {
   };
 
   removeToken = (tokens: any[], tokenStr: string) => {
-    const results = this.parserFor(tokenStr);
+    const results = this.parseFor(tokenStr);
     if (!results) return tokens;
 
     const [parser, parsedToken] = results;

--- a/src/views/documents/SearchStore.ts
+++ b/src/views/documents/SearchStore.ts
@@ -16,6 +16,7 @@ interface SearchQuery {
   journals: string[];
   titles?: string[];
   before?: string;
+  tags?: string[];
   texts?: string[];
   limit?: number;
 }
@@ -88,6 +89,10 @@ export class SearchStore {
       .map((token) => this.journals.idForName(token.value as string))
       .filter((token) => token) as string[];
 
+    const tags = this.tokens
+      .filter((t) => t.type === "tag")
+      .map((t) => t.value) as string[];
+
     // todo: Typescript doesn't know when I filter to type === 'title' its TitleTokens
     // its confused by the nodeMatch type
     const titles = this.tokens
@@ -103,7 +108,7 @@ export class SearchStore {
       before = beforeToken.value as string;
     }
 
-    return { journals, titles, texts, before };
+    return { journals, tags, titles, texts, before };
   };
 
   /**

--- a/src/views/documents/Sidebar.tsx
+++ b/src/views/documents/Sidebar.tsx
@@ -1,0 +1,127 @@
+import React, { useContext } from "react";
+import {
+  Pane,
+  SideSheet,
+  Card,
+  Heading,
+  UnorderedList,
+  ListItem,
+  FolderCloseIcon,
+} from "evergreen-ui";
+import { JournalsStoreContext } from "../../hooks/useJournalsLoader";
+import { JournalResponse } from "../../hooks/useClient";
+import { useTags } from "../../hooks/useTags";
+import { SidebarProps } from "./Layout";
+
+/**
+ * Sidebar for selecting journals or tags to search by.
+ */
+export function JournalSelectionSidebar(props: SidebarProps) {
+  const { isShown, setIsShown } = props;
+  const jstore = useContext(JournalsStoreContext);
+  const searchStore = props.search;
+
+  function search(journal: string) {
+    searchStore.setSearch([`in:${journal}`]);
+    setIsShown(false);
+    return false;
+  }
+
+  function searchTag(tag: string) {
+    searchStore.setSearch([`tag:${tag}`]);
+    setIsShown(false);
+    return false;
+  }
+
+  return (
+    <React.Fragment>
+      <SideSheet
+        position="left"
+        isShown={isShown}
+        onCloseComplete={() => setIsShown(false)}
+        preventBodyScrolling
+        containerProps={{
+          display: "flex",
+          flex: "1",
+          flexDirection: "column",
+        }}
+      >
+        <Pane zIndex={1} flexShrink={0} elevation={0} backgroundColor="white">
+          <Pane padding={16}>
+            <Heading size={600}>Journals</Heading>
+          </Pane>
+        </Pane>
+        <Pane flex="1" overflowY="scroll" background="tint1" padding={16}>
+          <JournalsCard
+            journals={jstore.active}
+            title="Active Journals"
+            search={search}
+          />
+          <JournalsCard
+            journals={jstore.archived}
+            title="Archived Journals"
+            search={search}
+          />
+          <TagsCard search={searchTag} />
+        </Pane>
+      </SideSheet>
+    </React.Fragment>
+  );
+}
+
+function TagsCard(props: { search: (tag: string) => boolean }) {
+  const { loading, error, tags } = useTags();
+
+  if (loading) {
+    return "loading...";
+  }
+
+  if (error) {
+    console.error("error loading tags", error);
+    return "error loading tags";
+  }
+
+  const tagItems = tags.map((t) => {
+    return (
+      <ListItem key={t} icon={FolderCloseIcon}>
+        <a href="" onClick={() => props.search(t)}>
+          {t}
+        </a>
+      </ListItem>
+    );
+  });
+
+  return (
+    <Card backgroundColor="white" elevation={0} padding={16} marginBottom={16}>
+      <Heading>Tags</Heading>
+      <UnorderedList>{tagItems}</UnorderedList>
+    </Card>
+  );
+}
+
+function JournalsCard(props: {
+  journals: JournalResponse[];
+  title: string;
+  search: (journalName: string) => boolean;
+}) {
+  if (!props.journals.length) {
+    return null;
+  }
+
+  const journals = props.journals.map((j) => {
+    return (
+      <ListItem key={j.id} icon={FolderCloseIcon}>
+        <a href="" onClick={() => props.search(j.name)}>
+          {j.name}
+        </a>
+      </ListItem>
+    );
+  });
+
+  return (
+    <Card backgroundColor="white" elevation={0} padding={16} marginBottom={16}>
+      <Heading>{props.title}</Heading>
+      <UnorderedList>{journals}</UnorderedList>
+    </Card>
+  );
+}

--- a/src/views/documents/search/SearchParser.test.ts
+++ b/src/views/documents/search/SearchParser.test.ts
@@ -106,6 +106,29 @@ suite("SearchParser", function () {
       });
     });
 
+    test("tag:", function () {
+      const pasrer = new SearchParser();
+      const tagToken = pasrer.parseToken("tag:javascript");
+
+      assert.exists(tagToken);
+      assert.deepEqual(tagToken, {
+        type: "tag",
+        value: "javascript",
+      });
+    });
+
+    test("tag: with #", function () {
+      const pasrer = new SearchParser();
+      const tagToken = pasrer.parseToken("tag:#javascript");
+
+      assert.exists(tagToken);
+      assert.deepEqual(tagToken, {
+        type: "tag",
+        // should remove the leading #
+        value: "javascript",
+      });
+    });
+
     test("title:", function () {
       const pasrer = new SearchParser();
       const titleToken = pasrer.parseToken("title:fix testing, sigh esm?");

--- a/src/views/documents/search/index.tsx
+++ b/src/views/documents/search/index.tsx
@@ -7,7 +7,10 @@ interface Props {
   store: SearchStore;
 }
 
-const TagSearch = (props: Props) => {
+/**
+ * SearchDocuments is a component that provides a search input for searching documents.
+ */
+const SearchDocuments = (props: Props) => {
   function onRemove(tag: string | React.ReactNode, idx: number) {
     if (typeof tag !== "string") return;
     props.store.removeToken(tag);
@@ -41,4 +44,4 @@ const TagSearch = (props: Props) => {
   );
 };
 
-export default observer(TagSearch);
+export default observer(SearchDocuments);

--- a/src/views/documents/search/parsers/filter.ts
+++ b/src/views/documents/search/parsers/filter.ts
@@ -86,7 +86,6 @@ function parseFilter(token: string): NodeMatch | undefined {
   } else {
     const nodeMatch = token.match(nodeRegex);
     if (nodeMatch && nodeTypes.includes(nodeMatch[1])) {
-      console.log("nodeMatch", nodeMatch[1]);
       return {
         type: nodeMatch[1],
         text: undefined,

--- a/src/views/documents/search/parsers/focus.ts
+++ b/src/views/documents/search/parsers/focus.ts
@@ -1,102 +1,102 @@
-import { FocusToken, SearchToken } from "../tokens";
+// import { FocusToken, SearchToken } from "../tokens";
 
-export class FocusTokenParser {
-  prefix = "focus:";
-  serialize = (token: FocusToken) => {
-    return `focus:${token.value.content}`;
-  };
+// export class FocusTokenParser {
+//   prefix = "focus:";
+//   serialize = (token: FocusToken) => {
+//     return `focus:${token.value.content}`;
+//   };
 
-  parse = (text: string): FocusToken | undefined => {
-    if (!text) return undefined;
-    return { type: "focus", value: parseHeading(text) };
-  };
+//   parse = (text: string): FocusToken | undefined => {
+//     if (!text) return undefined;
+//     return { type: "focus", value: parseHeading(text) };
+//   };
 
-  add = (tokens: SearchToken[], token: FocusToken) => {
-    // there can be only one...
-    // This isn't the right place to put this business logic...
-    const filtered = tokens.filter((t) => t.type !== "focus");
-    filtered.push(token);
+//   add = (tokens: SearchToken[], token: FocusToken) => {
+//     // there can be only one...
+//     // This isn't the right place to put this business logic...
+//     const filtered = tokens.filter((t) => t.type !== "focus");
+//     filtered.push(token);
 
-    return filtered;
-  };
+//     return filtered;
+//   };
 
-  remove = (tokens: SearchToken[], token: FocusToken) => {
-    // Find the token matching this one... and remove it...
-    return tokens.filter((t) => {
-      // Keep all non-focus tokens
-      if (t.type !== "focus") return true;
+//   remove = (tokens: SearchToken[], token: FocusToken) => {
+//     // Find the token matching this one... and remove it...
+//     return tokens.filter((t) => {
+//       // Keep all non-focus tokens
+//       if (t.type !== "focus") return true;
 
-      // Remove if it matches...
-      return (
-        t.value.content !== token.value.content ||
-        t.value.depth !== token.value.depth
-      );
-    });
-  };
-}
+//       // Remove if it matches...
+//       return (
+//         t.value.content !== token.value.content ||
+//         t.value.depth !== token.value.depth
+//       );
+//     });
+//   };
+// }
 
-/**
- * # foo -- Yes
- * ## foo -- Yes
- * #foo -- No
- * foo #bar # baz -- No
- */
-const hRegex = /^(#+) (.*)/;
+// /**
+//  * # foo -- Yes
+//  * ## foo -- Yes
+//  * #foo -- No
+//  * foo #bar # baz -- No
+//  */
+// const hRegex = /^(#+) (.*)/;
 
-/**
- * Get the text part of a heading search.
- *
- * Could be combined with extractHeading because of how I use it, but
- * good design is unclear to me atm.
- *
- * @param text -- search token for heading
- */
-function parseHeadingText(text: string): string {
-  const matches = text.match(hRegex);
-  if (!matches) return text;
-  return matches[2];
-}
+// /**
+//  * Get the text part of a heading search.
+//  *
+//  * Could be combined with extractHeading because of how I use it, but
+//  * good design is unclear to me atm.
+//  *
+//  * @param text -- search token for heading
+//  */
+// function parseHeadingText(text: string): string {
+//   const matches = text.match(hRegex);
+//   if (!matches) return text;
+//   return matches[2];
+// }
 
-type HeadingTag = "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+// type HeadingTag = "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
 
-function tagForDepth(text: string): HeadingTag {
-  if (!text.length || text.length > 6) {
-    console.warn(
-      "tagForDepth expected between 1-6 hashes, but got ",
-      text.length,
-      text,
-      "returning `h1` as a default",
-    );
-    return "h1";
-  }
+// function tagForDepth(text: string): HeadingTag {
+//   if (!text.length || text.length > 6) {
+//     console.warn(
+//       "tagForDepth expected between 1-6 hashes, but got ",
+//       text.length,
+//       text,
+//       "returning `h1` as a default",
+//     );
+//     return "h1";
+//   }
 
-  return `h${text.length}` as HeadingTag;
-}
+//   return `h${text.length}` as HeadingTag;
+// }
 
-/**
- * Parse a token as a focused heading command, convert
- * the text part to a node search query (i.e. searchStore.query.node)
- *
- * todo: Refactor searchStore.query.node to be more generic, and
- * to have a first class name (like "node search")
- * @param text
- */
-function parseHeading(text: string) {
-  // ['##', 'search text']
-  const matches = text.match(hRegex);
+// /**
+//  * Parse a token as a focused heading command, convert
+//  * the text part to a node search query (i.e. searchStore.query.node)
+//  *
+//  * todo: Refactor searchStore.query.node to be more generic, and
+//  * to have a first class name (like "node search")
+//  * @param text
+//  */
+// function parseHeading(text: string) {
+//   // ['##', 'search text']
+//   const matches = text.match(hRegex);
 
-  if (!matches) {
-    // Infer h1, preprend '# ' to search
-    return {
-      type: "heading",
-      content: "# " + text,
-      depth: "h1" as HeadingTag,
-    };
-  } else {
-    return {
-      type: "heading",
-      content: text, //matches[2],
-      depth: tagForDepth(matches[1]),
-    };
-  }
-}
+//   if (!matches) {
+//     // Infer h1, preprend '# ' to search
+//     return {
+//       type: "heading",
+//       content: "# " + text,
+//       depth: "h1" as HeadingTag,
+//     };
+//   } else {
+//     return {
+//       type: "heading",
+//       content: text, //matches[2],
+//       depth: tagForDepth(matches[1]),
+//     };
+//   }
+// }

--- a/src/views/documents/search/parsers/tag.ts
+++ b/src/views/documents/search/parsers/tag.ts
@@ -1,0 +1,53 @@
+import { SearchToken, TagToken } from "../tokens";
+
+export class TagTokenParser {
+  prefix = "tag:";
+
+  serialize = (token: TagToken) => {
+    return this.prefix + token.value;
+  };
+
+  parse = (text: string): TagToken | undefined => {
+    if (!text) return;
+
+    // trim # from the beginning of the tag
+    if (text.startsWith("#")) {
+      text = text.slice(1);
+    }
+
+    // remove spaces, snake_case
+    // changing value here changes it in the index view, but not ht eadd tags view
+    text = text.replace(/ /g, "_");
+    text = text.toLowerCase();
+
+    // max length, probably all search tokens need this? Or only this one since its persisted?
+    // todo: A consistent strategy here.
+    text = text.slice(0, 15);
+
+    return { type: "tag", value: text };
+  };
+
+  add = (tokens: SearchToken[], token: TagToken) => {
+    // there can be only one of each named journal
+    if (tokens.find((t) => t.type === "tag" && t.value === token.value)) {
+      return tokens;
+    }
+
+    // returning a copy is consistent with other methods,
+    // but feels useless
+    const copy = tokens.slice();
+    copy.push(token);
+    return copy;
+  };
+
+  remove = (tokens: SearchToken[], token: TagToken) => {
+    // Find the token matching this one... and remove it...
+    return tokens.filter((t) => {
+      // Keep all non-journal tokens
+      if (t.type !== "tag") return true;
+
+      // Remove if it matches...
+      return t.value !== token.value;
+    });
+  };
+}

--- a/src/views/documents/search/tokens.ts
+++ b/src/views/documents/search/tokens.ts
@@ -44,6 +44,11 @@ export type FocusToken = {
   };
 };
 
+export type TagToken = {
+  type: "tag";
+  value: string;
+};
+
 /**
  * Searching documents by title
  */
@@ -71,7 +76,8 @@ export type BeforeToken = {
 export type SearchToken =
   | FilterToken
   | JournalToken
-  | FocusToken
+  // | FocusToken
+  | TagToken
   | TitleToken
   | TextToken
   | BeforeToken;

--- a/src/views/edit/useEditableDocument.ts
+++ b/src/views/edit/useEditableDocument.ts
@@ -47,7 +47,7 @@ export function useEditableDocument(
       try {
         // if documentId -> This is an existing document
         if (documentId) {
-          const doc = await client.documents.findById({ documentId });
+          const doc = await client.documents.findById({ id: documentId });
           if (!isEffectMounted) return;
           setDocument(new EditableDocument(client, doc));
         } else {


### PR DESCRIPTION
Adds a basic interface for tagging documents, searching by tags, and quick-links for available tags / search to the sidebar. The implementation is very basic:

- Documents can be tagged with text, at the top level
- Documents can be searched by tags, with `tag:<mytagtext>`
- No tagging support within document text (but maybe in the future, #185)


The design is also basic. Ugly really. Butand inline with my sprints approach I kept the design minimal and used existing components, expecting to fully re-work design in the upcoming sprint #169 

<img width="715" alt="document tags" src="https://github.com/cloverich/chronicles/assets/1010084/acc0b95b-b987-46f4-aec1-bc4f15fe6cb3">


Tags will show up in the sidebar, with clickable search shortcuts. I used the same style as journal searching:

<img width="639" alt="sidebar" src="https://github.com/cloverich/chronicles/assets/1010084/79755c2f-9add-4087-83e2-a22937dec79c">

Closes #126 
