### PR TITLE
fix code block newline, 15->20 max tagsize

### DIFF
--- a/src/markdown/remark-slate-transformer/transformers/mdast-to-slate.ts
+++ b/src/markdown/remark-slate-transformer/transformers/mdast-to-slate.ts
@@ -264,21 +264,14 @@ export type Code = ReturnType<typeof createCodeBlock>;
 function createCodeBlock(node: mdast.Code) {
   const { value, lang, meta } = node;
 
-  // MDAST represents code blocks as a single string; our Plate code block represents
-  // internal code as a code_line element. Ostensibly this should be each line, but
-  // the PlateDOM seems to convert the full text to a single code_line element when it is modified.
-  // Unclear if this is a bug or a feature; making multiple lines here, but it may not be necessary.
-  // See the reverse transformation in slate-to-mdast.ts - createCode
-  const codeLines = value.split("\n").map((line, index, array) => {
-    const isLastLine = index === array.length - 1;
-    return { type: ELEMENT_CODE_LINE, text: isLastLine ? line : line + "\n" };
-  });
-
   return {
     type: ELEMENT_CODE_BLOCK,
     lang,
     meta,
-    children: codeLines,
+    // MDAST represents code blocks as a single string; our Plate code block represents
+    // internal code as a code_line element. Ostensibly this should be each line, but
+    // the PlateDOM seems to convert the full text to a single code_line element when it is modified.
+    children: [{ type: ELEMENT_CODE_LINE, text: value }],
   };
 }
 

--- a/src/markdown/remark-slate-transformer/transformers/slate-to-mdast.ts
+++ b/src/markdown/remark-slate-transformer/transformers/slate-to-mdast.ts
@@ -383,14 +383,16 @@ function createHtml(node: SlateNodes.Html): mdast.HTML {
 
 /**
  * Convert a Slate/Plate code block ("code_block") to an MDAST code block ("code").
+ *
+ *
+ * The slateInternal.Code type says its children are text nodes. However the
+ * Plate code block is wraps them in a code_line element.
+ * MDAST (seems to) expect just text in its code block element. This code
+ * implements that. See the reverse transformation in mdast-to-slate.ts - createCodeBlock
  */
 function createCode(node: SlateNodes.Code): mdast.Code {
   const { lang, meta } = node;
 
-  // The slateInternal.Code type says its children are text nodes. However the
-  // Plate code block is wrapping each of those in a `code_line` element.
-  // MDAST (seems to) expect just text in its code block element. This code
-  // implements that. See the reverse transformation in mdast-to-slate.ts - createCodeBlock
   // SNode.texts returns a generator that yields [{text: "foo"}, path] for each line
   // which looks like: [ { type: code_line, children : { text: ''}}]
   // TODO: Update Plate, then change the node's type

--- a/src/views/documents/search/parsers/tag.ts
+++ b/src/views/documents/search/parsers/tag.ts
@@ -22,7 +22,7 @@ export class TagTokenParser {
 
     // max length, probably all search tokens need this? Or only this one since its persisted?
     // todo: A consistent strategy here.
-    text = text.slice(0, 15);
+    text = text.slice(0, 20);
 
     return { type: "tag", value: text };
   };


### PR DESCRIPTION
- Fix issue in code block formatting where multtiple saves without a code block edit would add extra newlines to code blocks. Caused by how mdast <> slate transformation was interpreting code_line elements, fixed with trial and error as opposed to a principled approach
- Extended max size of tags from 15-20 as it was already too small to support tags I am using on other platforms. Max size is also set as a guestimate, and not based on a principled approach