### PR TITLE
support autoformatting shortcuts

### DIFF
--- a/src/views/edit/editor/index.tsx
+++ b/src/views/edit/editor/index.tsx
@@ -21,6 +21,9 @@ import {
   createIndentListPlugin,
   createIndentPlugin,
 
+  // @udecode/plate-autoformat
+  createAutoformatPlugin,
+
   // imported for resetNodePlugin
   unwrapCodeBlock,
   isSelectionAtCodeBlockStart,
@@ -90,6 +93,8 @@ import {
   LinkFloatingToolbar,
   VideoElement,
 } from "./elements";
+
+import { autoformatRules } from "./plugins/autoformat/autoformatRules";
 
 import { ELEMENT_VIDEO, createVideoPlugin } from "./plugins/createVideoPlugin";
 import { createFilesPlugin } from "./plugins/createFilesPlugin";
@@ -273,7 +278,19 @@ export default observer(
         }),
 
         createIndentListPlugin(),
+
+        // Ensures there is always a paragraph element at the end of the document; avoids
+        // document getting stuck with an image or other non-text element at the end, or
+        // being confused about how to exit an e.g. code block to add more content.
         createTrailingBlockPlugin({ type: ELEMENT_PARAGRAPH }),
+
+        // e.g. # -> h1, ``` -> code block, etc
+        createAutoformatPlugin({
+          options: {
+            rules: autoformatRules,
+            enableUndoOnDelete: true,
+          },
+        }),
       ],
       {
         components: {

--- a/src/views/edit/editor/plugins/autoformat/autoformatRules.ts
+++ b/src/views/edit/editor/plugins/autoformat/autoformatRules.ts
@@ -1,0 +1,204 @@
+import { AutoformatRule } from "@udecode/plate-autoformat";
+import { ELEMENT_BLOCKQUOTE } from "@udecode/plate-block-quote";
+import {
+  ELEMENT_CODE_BLOCK,
+  insertEmptyCodeBlock,
+} from "@udecode/plate-code-block";
+import {
+  ELEMENT_DEFAULT,
+  // insertNodes,
+  // setNodes,
+  // isBlock,
+} from "@udecode/plate-common";
+import { ELEMENT_H1, ELEMENT_H2, ELEMENT_H3 } from "@udecode/plate-heading";
+
+import { ELEMENT_LI, ELEMENT_OL, ELEMENT_UL } from "@udecode/plate-list";
+
+import { preFormat, formatList } from "./autoformatUtils";
+
+import {
+  MARK_BOLD,
+  MARK_CODE,
+  MARK_ITALIC,
+  MARK_STRIKETHROUGH,
+  MARK_UNDERLINE,
+} from "@udecode/plate-basic-marks";
+
+// These rules are configuration for autoformat plugin, pulled from plate docs at
+// https://platejs.org/docs/autoformat#autoformatrules
+// Consolidated and simplified the rules configuration into this single file.
+
+export const autoformatRules: AutoformatRule[] = [
+  {
+    mode: "block",
+    type: ELEMENT_H1,
+    match: "# ",
+    preFormat,
+  },
+  {
+    mode: "block",
+    type: ELEMENT_H2,
+    match: "## ",
+    preFormat,
+  },
+  {
+    mode: "block",
+    type: ELEMENT_H3,
+    match: "### ",
+    preFormat,
+  },
+
+  // I don't intend to support H4-H6 at this time
+  // {
+  //   mode: "block",
+  //   type: ELEMENT_H4,
+  //   match: "#### ",
+  //   preFormat,
+  // },
+  // {
+  //   mode: "block",
+  //   type: ELEMENT_H5,
+  //   match: "##### ",
+  //   preFormat,
+  // },
+  // {
+  //   mode: "block",
+  //   type: ELEMENT_H6,
+  //   match: "###### ",
+  //   preFormat,
+  // },
+  {
+    mode: "block",
+    type: ELEMENT_BLOCKQUOTE,
+    match: "> ",
+    preFormat,
+  },
+  {
+    mode: "block",
+    type: ELEMENT_CODE_BLOCK,
+    match: "```",
+    triggerAtBlockStart: false,
+    preFormat,
+    format: (editor) => {
+      insertEmptyCodeBlock(editor, {
+        defaultType: ELEMENT_DEFAULT,
+        insertNodesOptions: { select: true },
+      });
+    },
+  },
+  {
+    mode: "block",
+    type: ELEMENT_LI,
+    match: ["* ", "- "],
+    preFormat,
+    format: (editor) => formatList(editor, ELEMENT_UL),
+  },
+  {
+    mode: "block",
+    type: ELEMENT_LI,
+    match: ["1. ", "1) "],
+    preFormat,
+    format: (editor) => formatList(editor, ELEMENT_OL),
+  },
+  {
+    mode: "mark",
+    type: [MARK_BOLD, MARK_ITALIC],
+    match: "***",
+  },
+  {
+    mode: "mark",
+    type: [MARK_UNDERLINE, MARK_ITALIC],
+    match: "__*",
+  },
+  {
+    mode: "mark",
+    type: [MARK_UNDERLINE, MARK_BOLD],
+    match: "__**",
+  },
+  {
+    mode: "mark",
+    type: [MARK_UNDERLINE, MARK_BOLD, MARK_ITALIC],
+    match: "___***",
+  },
+  {
+    mode: "mark",
+    type: MARK_BOLD,
+    match: "**",
+  },
+  {
+    mode: "mark",
+    type: MARK_UNDERLINE,
+    match: "__",
+  },
+  {
+    mode: "mark",
+    type: MARK_ITALIC,
+    match: "*",
+  },
+  {
+    mode: "mark",
+    type: MARK_ITALIC,
+    match: "_",
+  },
+  {
+    mode: "mark",
+    type: MARK_STRIKETHROUGH,
+    match: "~~",
+  },
+  {
+    mode: "mark",
+    type: MARK_CODE,
+    match: "`",
+  },
+  // I haven't set these up yet
+  // {
+  //   mode: "mark",
+  //   type: MARK_SUPERSCRIPT,
+  //   match: "^",
+  // },
+  // {
+  //   mode: "mark",
+  //   type: MARK_SUBSCRIPT,
+  //   match: "~",
+  // },
+  // {
+  //   mode: "mark",
+  //   type: MARK_HIGHLIGHT,
+  //   match: "==",
+  // },
+  // {
+  //   mode: "mark",
+  //   type: MARK_HIGHLIGHT,
+  //   match: "≡",
+  // },
+  // {
+  //   mode: "block",
+  //   type: ELEMENT_TODO_LI,
+  //   match: "[] ",
+  // },
+  // {
+  //   mode: "block",
+  //   type: ELEMENT_TODO_LI,
+  //   match: "[x] ",
+  //   format: (editor) =>
+  //     setNodes<TTodoListItemElement>(
+  //       editor,
+  //       { type: ELEMENT_TODO_LI, checked: true },
+  //       {
+  //         match: (n) => isBlock(editor, n),
+  //       },
+  //     ),
+  // },
+  // {
+  //   mode: "block",
+  //   type: ELEMENT_HR,
+  //   match: ["---", "—-", "___ "],
+  //   format: (editor) => {
+  //     setNodes(editor, { type: ELEMENT_HR });
+  //     insertNodes(editor, {
+  //       type: ELEMENT_DEFAULT,
+  //       children: [{ text: "" }],
+  //     });
+  //   },
+  // },
+];

--- a/src/views/edit/editor/plugins/autoformat/autoformatUtils.ts
+++ b/src/views/edit/editor/plugins/autoformat/autoformatUtils.ts
@@ -1,0 +1,52 @@
+import type { AutoformatBlockRule } from "@udecode/plate-autoformat";
+
+import {
+  ELEMENT_CODE_BLOCK,
+  ELEMENT_CODE_LINE,
+} from "@udecode/plate-code-block";
+import {
+  type PlateEditor,
+  getParentNode,
+  isElement,
+  isType,
+} from "@udecode/plate-common";
+import { toggleList, unwrapList } from "@udecode/plate-list";
+
+// NOTE: Plate documentation provides examples of configuring autoformat rules; they reference
+// a few functions like "preFormat" that are not in the autoformat plugin package, but instead
+// a part of the demo / playground code. Yet oddly, there are tests _for these functions_ within
+// the @udecode/plate-autoformat package; so perhaps these will be incorporated into that package
+// in a future version, and these can be deleted. Will try to avoid changing them for now.
+
+export const preFormat: AutoformatBlockRule["preFormat"] = (editor) =>
+  unwrapList(editor);
+
+export const format = (editor: PlateEditor, customFormatting: any) => {
+  if (editor.selection) {
+    const parentEntry = getParentNode(editor, editor.selection);
+
+    if (!parentEntry) return;
+
+    const [node] = parentEntry;
+
+    if (
+      isElement(node) &&
+      !isType(editor, node, ELEMENT_CODE_BLOCK) &&
+      !isType(editor, node, ELEMENT_CODE_LINE)
+    ) {
+      customFormatting();
+    }
+  }
+};
+
+export const formatList = (editor: PlateEditor, elementType: string) => {
+  format(editor, () =>
+    toggleList(editor, {
+      type: elementType,
+    }),
+  );
+};
+
+export const formatText = (editor: PlateEditor, text: string) => {
+  format(editor, () => editor.insertText(text));
+};


### PR DESCRIPTION
Add support for auto-converting well known markdown text into the corresponding element / mark, i.e. markdown formatting shortcuts:

- `# `: Transforms into `<h1>`
- `## `: Transforms into `<h2>`
- `### `: Transforms into `<h3>`
- `> `: Transforms into `blockquote`
- `\`\`\``: Transforms into `code block`
- `* ` or `- `: Transforms into `unordered list item`
- `1. ` or `1) `: Transforms into `ordered list item`
- `***`: Transforms into `bold` and `italic`
- `__*`: Transforms into `underline` and `italic`
- `__**`: Transforms into `underline` and `bold`
- `___***`: Transforms into `underline`, `bold`, and `italic`
- `**`: Transforms into `bold`
- `__`: Transforms into `underline`
- `*`: Transforms into `italic`
- `_`: Transforms into `italic`
- `~~`: Transforms into `strikethrough`
- `\``: Transforms into `code`



This feature implementation is already well defined by plate as "[autoformat](https://platejs.org/docs/autoformat)", and it was mostly a drop-in with some light modification and documentation. 

Closes #80 