### PR TITLE
fix code_block pasting

### DIFF
--- a/src/views/edit/editor/index.tsx
+++ b/src/views/edit/editor/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import { withProps } from "@udecode/cn";
 import { observer } from "mobx-react-lite";
 import { Node as SNode } from "slate";
@@ -95,6 +95,7 @@ import {
 } from "./elements";
 
 import { autoformatRules } from "./plugins/autoformat/autoformatRules";
+import { createCodeBlockNormalizationPlugin } from "./plugins/createCodeBlockNormalizationPlugin";
 
 import { ELEMENT_VIDEO, createVideoPlugin } from "./plugins/createVideoPlugin";
 import { createFilesPlugin } from "./plugins/createFilesPlugin";
@@ -125,6 +126,8 @@ export default observer(
     // todo: Commented out stuff is post-copy paste edit from plate-ui (as recommended), and should used to guide next steps.
     const plugins = createPlugins(
       [
+        createCodeBlockNormalizationPlugin(),
+
         // editor
         createReactPlugin(), // withReact
         createHistoryPlugin(), // withHistory

--- a/src/views/edit/editor/plugins/createCodeBlockNormalizationPlugin.tsx
+++ b/src/views/edit/editor/plugins/createCodeBlockNormalizationPlugin.tsx
@@ -1,0 +1,77 @@
+import { createPluginFactory } from "@udecode/plate-common";
+import { Editor, Range, Transforms } from "slate";
+import { ELEMENT_CODE_BLOCK, ELEMENT_CODE_LINE } from "@udecode/plate";
+
+/**
+ * This plugin handles pasted code to ensure it is pasted as a single block. Prior to this pasting
+ * a block of code into the editor would generate a new code_block for each line. This solution
+ * was not extensively tested!
+ */
+export const createCodeBlockNormalizationPlugin = createPluginFactory({
+  key: "customPlugin",
+  withOverrides: (editor) => {
+    // todo: types -- Various methods below do `editor as Editor` because editor here is PlateEditor.
+    // Unsure what the right way to cast this is -- Grepped a few examples from Plate's codebase
+    // and they do `Editor as any` which seems wrong.
+    // Also, `node as any` -- Slate's methods aren't expecting `type` on Node but its foundational
+    // to custom elements.
+    const { normalizeNode, insertData } = editor;
+
+    editor.normalizeNode = ([node, path]) => {
+      if (node.type === ELEMENT_CODE_BLOCK) {
+        const blockEntries = Array.from(
+          Editor.nodes(editor as Editor, {
+            at: path,
+            match: (n) => (n as any).type === ELEMENT_CODE_LINE,
+          }),
+        );
+
+        if (blockEntries.length > 1) {
+          const [firstCodeLine, firstCodeLinePath] = blockEntries[0];
+          blockEntries.slice(1).forEach(([, codeLinePath]) => {
+            Transforms.mergeNodes(editor as Editor, { at: codeLinePath });
+          });
+          Transforms.setNodes(
+            editor as Editor,
+            { type: ELEMENT_CODE_BLOCK } as any,
+            { at: firstCodeLinePath },
+          );
+        }
+      }
+      normalizeNode([node, path]);
+    };
+
+    editor.insertData = (data: DataTransfer) => {
+      const text = data.getData("text/plain");
+      if (
+        text &&
+        Editor.above(editor as Editor, {
+          match: (n: any) => n.type === ELEMENT_CODE_BLOCK,
+        })
+      ) {
+        const lines = text.split("\n");
+        const { selection } = editor;
+        if (selection && Range.isCollapsed(selection)) {
+          Transforms.insertText(editor as Editor, lines.join("\n"), {
+            at: selection,
+          });
+        } else {
+          lines.forEach((line) => {
+            Transforms.insertText(editor as Editor, line);
+            Transforms.insertNodes(
+              editor as Editor,
+              {
+                type: ELEMENT_CODE_LINE,
+                children: [{ text: "" }],
+              } as any,
+            );
+          });
+        }
+        return;
+      }
+      insertData(data);
+    };
+
+    return editor;
+  },
+});


### PR DESCRIPTION
- adds a custom normalization step when pasting code, to fix an issue where pasting blobs of code would generate a new code_block element for each line


This closes #85 (specifically the _pasting_ of code)