### PR TITLE
code block fixes

### DIFF
--- a/src/views/edit/editor/index.tsx
+++ b/src/views/edit/editor/index.tsx
@@ -342,20 +342,18 @@ export default observer(
     );
 
     return (
-      <>
-        <Plate
-          initialValue={value as any}
-          onChange={setValue}
-          plugins={plugins}
-          readOnly={saving}
-        >
-          <EditorToolbar
-            selectedEditorMode={selectedEditorMode}
-            setSelectedEditorMode={setSelectedEditorMode}
-          />
-          <PlateContent placeholder="Type..." />
-        </Plate>
-      </>
+      <Plate
+        initialValue={value as any}
+        onChange={setValue}
+        plugins={plugins}
+        readOnly={saving}
+      >
+        <EditorToolbar
+          selectedEditorMode={selectedEditorMode}
+          setSelectedEditorMode={setSelectedEditorMode}
+        />
+        <PlateContent placeholder="Type..." />
+      </Plate>
     );
   },
 );

--- a/src/views/edit/editor/plugins/createCodeBlockNormalizationPlugin.tsx
+++ b/src/views/edit/editor/plugins/createCodeBlockNormalizationPlugin.tsx
@@ -15,60 +15,43 @@ export const createCodeBlockNormalizationPlugin = createPluginFactory({
     // and they do `Editor as any` which seems wrong.
     // Also, `node as any` -- Slate's methods aren't expecting `type` on Node but its foundational
     // to custom elements.
-    const { normalizeNode, insertData } = editor;
-
-    editor.normalizeNode = ([node, path]) => {
-      if (node.type === ELEMENT_CODE_BLOCK) {
-        const blockEntries = Array.from(
-          Editor.nodes(editor as Editor, {
-            at: path,
-            match: (n) => (n as any).type === ELEMENT_CODE_LINE,
-          }),
-        );
-
-        if (blockEntries.length > 1) {
-          const [firstCodeLine, firstCodeLinePath] = blockEntries[0];
-          blockEntries.slice(1).forEach(([, codeLinePath]) => {
-            Transforms.mergeNodes(editor as Editor, { at: codeLinePath });
-          });
-          Transforms.setNodes(
-            editor as Editor,
-            { type: ELEMENT_CODE_BLOCK } as any,
-            { at: firstCodeLinePath },
-          );
-        }
-      }
-      normalizeNode([node, path]);
-    };
+    const { insertData } = editor;
 
     editor.insertData = (data: DataTransfer) => {
       const text = data.getData("text/plain");
       if (
-        text &&
-        Editor.above(editor as Editor, {
+        !text ||
+        !Editor.above(editor as Editor, {
           match: (n: any) => n.type === ELEMENT_CODE_BLOCK,
         })
       ) {
-        const lines = text.split("\n");
-        const { selection } = editor;
-        if (selection && Range.isCollapsed(selection)) {
-          Transforms.insertText(editor as Editor, lines.join("\n"), {
-            at: selection,
-          });
-        } else {
-          lines.forEach((line) => {
-            Transforms.insertText(editor as Editor, line);
-            Transforms.insertNodes(
-              editor as Editor,
-              {
-                type: ELEMENT_CODE_LINE,
-                children: [{ text: "" }],
-              } as any,
-            );
-          });
-        }
+        insertData(data);
         return;
       }
+
+      const lines = text.split("\n");
+      const { selection } = editor;
+      if (selection && Range.isCollapsed(selection)) {
+        // When pasting at cursor (no text / blocks selected), insert as a single block.
+        Transforms.insertText(editor as Editor, lines.join("\n"), {
+          at: selection,
+        });
+      } else {
+        // Pasting when selecting multiple lines; if its within a code block, it ends up as one block.
+        // I think Plates createCodeBlockPlugin (from createBasicPlugins) is normalizing this to a single block...
+        // unclear if this code makes sense.
+        lines.forEach((line) => {
+          Transforms.insertText(editor as Editor, line);
+          Transforms.insertNodes(
+            editor as Editor,
+            {
+              type: ELEMENT_CODE_LINE,
+              children: [{ text: "" }],
+            } as any,
+          );
+        });
+      }
+
       insertData(data);
     };
 

--- a/src/views/edit/index.tsx
+++ b/src/views/edit/index.tsx
@@ -279,7 +279,8 @@ const DocumentEditView = observer((props: DocumentEditProps) => {
   // flexGrows are needed so save / edit buttons are at bottom on both empty documents
   // and scrollable documents
   return (
-    <Pane flexGrow={1} display="flex" flexDirection="column">
+    // NOTE: width: 100% prevents child code_blocks (and maybe others) from overflowing
+    <Pane flexGrow={1} display="flex" flexDirection="column" width="100%">
       <div style={{ marginBottom: "24px" }}>
         <a
           onClick={goBack}


### PR DESCRIPTION
- fix code block pasting normalization error
- fix issue where pasting into a code block would overflow, then produce multiple child code blocks
- fix long lines in code blocks from overflowing and increasing width of the parent editor (they internaly scroll-x instead)
- handle ts language shortcuts (many older notes use this short-hand, which is supported by prism)

Closes #85 
Closes #184 