### PR TITLE
add version to packaged app

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -67,6 +67,15 @@ cp -r src/*.bundle.* dist/
 cp package.json dist/
 cp yarn.lock dist/
 
+# Most recent tag, and commits / count since tag to help version script determine if this is
+# a release (tag), pre-release (commits since), or dev (uncommited) build
+export GIT_TAG=$(git describe --tags --abbrev=0)
+export GIT_COMMIT_SHA=$(git rev-parse --short HEAD)
+export GIT_COMMIT_COUNT=$(git rev-list --count HEAD ^$GIT_TAG)
+export BUILD_DATE=$(date +%Y%m%d)
+export GIT_UNCOMMITTED_CHANGES=$(if [ -n "$(git status --porcelain)" ]; then echo "true"; else echo "false"; fi)
+node ./scripts/set-packaged-version.js
+
 # todo: This is installing dev dependencies which, because of esbuild, should not be needed.
 # When I use install --production, the final build complains it cannot find electron
 # Could probably just install --production then manually add electron? Or munge the copied

--- a/scripts/set-packaged-version.js
+++ b/scripts/set-packaged-version.js
@@ -1,0 +1,47 @@
+// ./scripts/set-packaged-version.js
+const fs = require("fs");
+const path = require("path");
+
+const inferVersionFromEnv = () => {
+  const tag = process.env.GIT_TAG || "0.0.0";
+  const commitSha = process.env.GIT_COMMIT_SHA || "unknown";
+  const commitCount = process.env.GIT_COMMIT_COUNT || "0";
+  const date =
+    process.env.BUILD_DATE ||
+    new Date().toISOString().split("T")[0].replace(/-/g, "");
+
+  // If the tag is a release tag, we don't need to modify it
+  let version = tag;
+
+  // If there are uncommitted changes or commits since the last tag, we need to
+  // bump the version and amend it with the commit / date information
+  if (commitCount !== "0" || process.env.GIT_UNCOMMITTED_CHANGES === "true") {
+    const [major, minor, patch] = tag.split("."); // v0, 4, 0
+    const nextTag = `${major}.${parseInt(minor) + 1}.${patch}`; // v0.5.0
+
+    if (process.env.GIT_UNCOMMITTED_CHANGES === "true") {
+      version = `${nextTag}-dev-uncommited-${date}`;
+    } else if (commitCount !== "0") {
+      version = `${nextTag}-dev-${commitCount}-${date}-${commitSha}`;
+    }
+  }
+
+  return { version, commitSha };
+};
+
+const setVersionInPackageJson = (version, commitSha) => {
+  const packageJsonPath = path.join(__dirname, "../dist", "package.json");
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+
+  packageJson.version = version;
+  packageJson.buildMetadata = {
+    version,
+    commit: commitSha,
+  };
+
+  fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
+  console.log(`Updated version to ${version}`);
+};
+
+const { version, commitSha } = inferVersionFromEnv();
+setVersionInPackageJson(version, commitSha);


### PR DESCRIPTION
This is just the version in the about panel; I tried to make it nicer but ran into issues w/ the packaged script choking on finding `package.json`; also apparently I need a better logging solution when running in packaged mode. 

- Tagged version: v0.5.0
- Untagged, commits: v0.5.0-dev-18-20240629-<sha> (if last tag v0.4.0)
- Uncommited: v0.5.0-dev-uncomitted-20240629 (if last tag v0.4.0)

Should help me keep straight which release I have installed. Closes #71 although obviously without the changelog; Github releases page has that for now. 