### PR TITLE
sync document crud with search

### DIFF
--- a/src/container.tsx
+++ b/src/container.tsx
@@ -5,6 +5,7 @@ import Preferences from "./views/preferences";
 import Journals from "./views/journals";
 import Documents from "./views/documents";
 import Editor from "./views/edit";
+import DocumentCreator from "./views/create";
 import { SearchProvider } from "./views/documents/SearchProvider";
 import {
   useJournalsLoader,
@@ -12,6 +13,7 @@ import {
 } from "./hooks/useJournalsLoader";
 import { Alert } from "evergreen-ui";
 import { Routes, Route, Navigate } from "react-router-dom";
+import "react-day-picker/dist/style.css";
 
 export default observer(function Container() {
   const { journalsStore, loading, loadingErr } = useJournalsLoader();
@@ -42,7 +44,7 @@ export default observer(function Container() {
           <Route path="preferences" element={<Preferences />} />
           <Route path="documents" element={<SearchProvider />}>
             <Route index element={<Documents />} />
-            <Route path="edit/new" element={<Editor />} />
+            <Route path="edit/new" element={<DocumentCreator />} />
             <Route path="edit/:document" element={<Editor />} />
           </Route>
           <Route path="*" element={<Navigate to="documents" replace />} />

--- a/src/hooks/stores/journals.ts
+++ b/src/hooks/stores/journals.ts
@@ -100,6 +100,27 @@ export class JournalsStore {
 
     this.saving = false;
   };
+
+  /**
+   * Determines the default journal to use when creating a new document.
+   *
+   * todo(test): When one or multiple journals are selected, returns the first
+   * todo(test): When no journals are selected, returns the first active journal
+   * todo(test): When archived journal selected, returns the selected (archived) journal
+   */
+  defaultJournal = (selectedJournals: string[]) => {
+    const selectedId = this.journals.find((j) =>
+      selectedJournals.includes(j.name),
+    )?.id;
+
+    if (selectedId) {
+      return selectedId;
+    } else {
+      // todo: defaulting to first journal, but could use logic such as the last selected
+      // journal, etc, once that is in place
+      return this.active[0].id;
+    }
+  };
 }
 
 export type IJournalStore = JournalsStore;

--- a/src/hooks/useJournalsLoader.ts
+++ b/src/hooks/useJournalsLoader.ts
@@ -3,11 +3,8 @@ import { JournalsStore } from "./stores/journals";
 import { JournalResponse } from "../preload/client/journals";
 import useClient from "./useClient";
 
-export const JournalsStoreContext = React.createContext<JournalsStore>(
-  // This cast combines with the top-level container ensuring journals are loaded,
-  // so all downstream components that need journals (most of the app) can rely
-  // on them being preloaded and avoid the null checks
-  null as any,
+export const JournalsStoreContext = React.createContext<JournalsStore | null>(
+  null,
 );
 
 /**

--- a/src/views/create/index.tsx
+++ b/src/views/create/index.tsx
@@ -1,0 +1,57 @@
+import React, { useContext, useEffect, useState } from "react";
+import { observer } from "mobx-react-lite";
+import { EditLoadingComponent } from "../edit/loading";
+import { useIsMounted } from "../../hooks/useIsMounted";
+import { JournalsStoreContext } from "../../hooks/useJournalsLoader";
+import { useNavigate } from "react-router-dom";
+import { SearchStoreContext } from "../documents/SearchStore";
+import useClient from "../../hooks/useClient";
+
+// Creates a new document and immediately navigates to it
+function useCreateDocument() {
+  const journalsStore = useContext(JournalsStoreContext)!;
+
+  // NOTE: Could move this hook but, but it assumes searchStore is defined, and its setup
+  // in the root documents view. So better to keep it here for now.
+  const searchStore = useContext(SearchStoreContext)!;
+  const navigate = useNavigate();
+  const client = useClient();
+  const isMounted = useIsMounted();
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    (async function () {
+      if (!isMounted) return;
+
+      try {
+        const document = await client.documents.save({
+          content: "",
+          journalId: journalsStore.defaultJournal(searchStore.selectedJournals),
+          tags: [], // todo: tagsStore.defaultTags;
+        });
+
+        if (!isMounted) return;
+
+        // Ensure the document is added to the search, so its available when user hits
+        // back (even when that doesn't make sense!)
+        searchStore.updateSearch(document, "create");
+        navigate(`/documents/edit/${document.id}`, { replace: true });
+      } catch (err) {
+        console.error("Error creating document", err);
+        if (!isMounted) return;
+        setError(err as Error);
+      }
+    })();
+  }, []);
+
+  return { error };
+}
+
+// Creates a new document and immediately navigates to it
+function DocumentCreator() {
+  const { error } = useCreateDocument();
+
+  return <EditLoadingComponent error={error} />;
+}
+
+export default observer(DocumentCreator);

--- a/src/views/documents/SearchProvider.tsx
+++ b/src/views/documents/SearchProvider.tsx
@@ -6,7 +6,8 @@ import { JournalsStoreContext } from "../../hooks/useJournalsLoader";
 import { SearchStore, SearchStoreContext } from "./SearchStore";
 import { LayoutDummy } from "../../layout";
 
-export function SearchProvider(props: any) {
+// Sets up document search and its context
+export function SearchProvider() {
   const jstore = useContext(JournalsStoreContext);
   const client = useClient();
   const [params, setParams] = useSearchParams();

--- a/src/views/documents/Sidebar.tsx
+++ b/src/views/documents/Sidebar.tsx
@@ -19,7 +19,7 @@ import { Icons } from "../../components/icons";
  */
 export function JournalSelectionSidebar(props: SidebarProps) {
   const { isShown, setIsShown } = props;
-  const jstore = useContext(JournalsStoreContext);
+  const jstore = useContext(JournalsStoreContext)!;
   const searchStore = props.search;
 
   function search(journal: string) {

--- a/src/views/documents/index.tsx
+++ b/src/views/documents/index.tsx
@@ -3,14 +3,14 @@ import { observer } from "mobx-react-lite";
 import { Heading, Paragraph, Pane } from "evergreen-ui";
 
 import { JournalsStoreContext } from "../../hooks/useJournalsLoader";
-import { SearchStoreContext, SearchStore } from "./SearchStore";
+import { SearchStore, useSearchStore } from "./SearchStore";
 import { DocumentItem } from "./DocumentItem";
 import { useNavigate } from "react-router-dom";
 import { Layout } from "./Layout";
 
 function DocumentsContainer() {
-  const journalsStore = useContext(JournalsStoreContext);
-  const searchStore = useContext(SearchStoreContext);
+  const journalsStore = useContext(JournalsStoreContext)!;
+  const searchStore = useSearchStore()!;
   const navigate = useNavigate();
 
   function edit(docId: string) {

--- a/src/views/edit/loading.tsx
+++ b/src/views/edit/loading.tsx
@@ -5,7 +5,7 @@ import { css } from "emotion";
 import { useNavigate } from "react-router-dom";
 
 export interface LoadingComponentProps {
-  error?: Error;
+  error?: Error | null;
 }
 
 export const placeholderDate = new Date().toISOString().slice(0, 10);
@@ -38,7 +38,7 @@ export const EditLoadingComponent = observer((props: LoadingComponentProps) => {
               cursor: pointer;
             `}
           >
-            Unknown
+            Loading...
           </span>
         </div>
         <div

--- a/src/views/journals/index.tsx
+++ b/src/views/journals/index.tsx
@@ -22,7 +22,7 @@ import { RouteProps } from "react-router-dom";
 // journal added after successful save
 // journals load and are displayed
 function Journals(props: RouteProps) {
-  const store = useContext(JournalsStoreContext);
+  const store = useContext(JournalsStoreContext)!;
   const [name, setName] = useState<string>("");
 
   function save() {
@@ -153,7 +153,7 @@ function Journals(props: RouteProps) {
  * UI and hook for toggling archive state on a journal
  */
 function JournalArchiveButton(props: { journal: JournalResponse }) {
-  const store = useContext(JournalsStoreContext);
+  const store = useContext(JournalsStoreContext)!;
 
   async function toggleArchive(journal: JournalResponse) {
     const isArchiving = !!journal.archivedAt;


### PR DESCRIPTION
Re-work document create, update, and delete operations to be (mostly) synchronized with search, such that navigating back to the documents list after create / edit / delete reflects the changes in search results.

- When creatnig a document, auto-save it and navigate to edit view, adding to current search
- When editing, update the document (title, etc) so its reflected in search
- When deleting, remove the document from the search results

Also re-work document creation to be fully separate from EditableDocument, and remove  hack that hid the fact that (technically) stores could be null when pulled from context; updated all calls to append ! so its documented what is happening; hopefully this protects against future refactors where consumers are yanked out of the provider that sets up the context.

Closes #170 
Closes #189 
