### PR TITLE
fix code block doubling pastes

### DIFF
--- a/src/views/edit/editor/plugins/createCodeBlockNormalizationPlugin.tsx
+++ b/src/views/edit/editor/plugins/createCodeBlockNormalizationPlugin.tsx
@@ -31,28 +31,11 @@ export const createCodeBlockNormalizationPlugin = createPluginFactory({
 
       const lines = text.split("\n");
       const { selection } = editor;
-      if (selection && Range.isCollapsed(selection)) {
-        // When pasting at cursor (no text / blocks selected), insert as a single block.
+      if (selection) {
         Transforms.insertText(editor as Editor, lines.join("\n"), {
           at: selection,
         });
-      } else {
-        // Pasting when selecting multiple lines; if its within a code block, it ends up as one block.
-        // I think Plates createCodeBlockPlugin (from createBasicPlugins) is normalizing this to a single block...
-        // unclear if this code makes sense.
-        lines.forEach((line) => {
-          Transforms.insertText(editor as Editor, line);
-          Transforms.insertNodes(
-            editor as Editor,
-            {
-              type: ELEMENT_CODE_LINE,
-              children: [{ text: "" }],
-            } as any,
-          );
-        });
       }
-
-      insertData(data);
     };
 
     return editor;


### PR DESCRIPTION
When pasting code into code block, the content was doubling. This was caused by the insertData routine being outside of the multi-line block. But after fixing, I discovered another bug where the normalization routine was putting code_lines outside of blocks, which resulted in the serialized content being removed (because mdast doesnt know about code_lines). Anyways, outright removing the normalization logic seems to fix so... here we are.


Closes #204 