### PR TITLE
Note linking

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test": "mocha 'src/**/*.test.bundle.js'"
   },
   "dependencies": {
+    "@ariakit/react": "^0.4.8",
     "ajv": "^8.6.2",
     "ajv-formats": "^2.1.0",
     "better-sqlite3": "^9.2.2",

--- a/src/markdown/remark-slate-transformer/transformers/mdast-to-slate.ts
+++ b/src/markdown/remark-slate-transformer/transformers/mdast-to-slate.ts
@@ -13,7 +13,10 @@ import {
   ELEMENT_UL,
   ELEMENT_CODE_BLOCK,
   ELEMENT_CODE_LINE,
+  ELEMENT_LINK,
 } from "@udecode/plate"; // todo: sub-package which has only elements?
+
+import { toSlateLink } from "../../../views/edit/editor/features/note-linking/toMdast";
 
 export type Decoration = {
   [key in (
@@ -43,7 +46,6 @@ function convertNodes(nodes: mdast.Content[], deco: Decoration): slate.Node[] {
   }, []);
 }
 
-// NOTE: Added
 const DECORATION_MAPPING = {
   emphasis: "italic",
   strong: "bold",
@@ -365,9 +367,14 @@ function createBreak(node: mdast.Break) {
 export type Link = ReturnType<typeof createLink>;
 
 function createLink(node: mdast.Link, deco: Decoration) {
-  const { type, children, url, title } = node;
+  const { children, url, title } = node;
+
+  const res = toSlateLink({ url, children, deco, convertNodes });
+
+  if (res) return res;
+
   return {
-    type: "a", // NOTE: Default plate link component uses "a"
+    type: ELEMENT_LINK,
     children: convertNodes(children, deco),
     url,
     title,

--- a/src/markdown/remark-slate-transformer/transformers/slate-to-mdast.ts
+++ b/src/markdown/remark-slate-transformer/transformers/slate-to-mdast.ts
@@ -9,7 +9,6 @@ import { Node as SNode } from "slate";
 // NOTE: https://github.com/inokawa/remark-slate-transformer/issues/31
 import { unPrefixUrl } from "../../../hooks/images";
 
-// NOTE: added, and a good example of what changes I would want to make to this library!
 import {
   ELEMENT_LI,
   ELEMENT_LIC,
@@ -17,7 +16,12 @@ import {
   ELEMENT_TODO_LI,
   ELEMENT_UL,
   ELEMENT_CODE_BLOCK,
-} from "@udecode/plate"; // todo: sub-package which has only elements?
+} from "@udecode/plate";
+
+import {
+  createLinkFromNoteLinkFactory,
+  ELEMENT_NOTE_LINK,
+} from "../../../views/edit/editor/features/note-linking";
 
 // NOTE: Changed these, they were just mirroring mdasts' before
 // which doesn't make sense
@@ -56,7 +60,7 @@ function createMdastRoot(node: slate.Node): unistLib.Node {
   return root as any as unistLib.Node;
 }
 
-function convertNodes(nodes: slate.Node[]): unistLib.Node[] {
+export function convertNodes(nodes: slate.Node[]): unistLib.Node[] {
   const mdastNodes: unistLib.Node[] = [];
   let textQueue: SlateNodes.Text[] = [];
   for (let i = 0; i <= nodes.length; i++) {
@@ -238,6 +242,8 @@ function createMdastNode(
       return createImage(node);
     case "linkReference":
       return createLinkReference(node);
+    case ELEMENT_NOTE_LINK:
+      return createLinkFromNoteLink(node);
     case "imageReference":
       return createImageReference(node);
     case "footnote":
@@ -461,12 +467,14 @@ function createBreak(node: SlateNodes.Break): mdast.Break {
 function createLink(node: SlateNodes.Link): mdast.Link {
   const { type, url, title, children } = node;
   return {
-    type: "link", // note: changes from type to type: "link" so it can accept "a", see the switch statement
-    url, // note: converted, "as any" added because mdast.Link thinks its url and not link?
+    type: "link",
+    url,
     title,
-    children: convertNodes(children) as any as mdast.Link["children"],
-  } as any;
+    children: convertNodes(children) as any, //
+  };
 }
+
+const createLinkFromNoteLink = createLinkFromNoteLinkFactory(convertNodes);
 
 function createImage(node: SlateNodes.Image | SlateNodes.Video): mdast.Image {
   const { type, url, title, alt } = node;

--- a/src/views/edit/editor/components/InlineCombobox.tsx
+++ b/src/views/edit/editor/components/InlineCombobox.tsx
@@ -1,0 +1,368 @@
+import React, {
+  type HTMLAttributes,
+  type ReactNode,
+  type RefObject,
+  createContext,
+  forwardRef,
+  startTransition,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+
+import type { PointRef } from "slate";
+
+import {
+  Combobox,
+  ComboboxItem,
+  type ComboboxItemProps,
+  ComboboxPopover,
+  ComboboxProvider,
+  Portal,
+  useComboboxContext,
+  useComboboxStore,
+} from "@ariakit/react";
+import { cn } from "@udecode/cn";
+import {
+  type UseComboboxInputResult,
+  filterWords,
+  useComboboxInput,
+  useHTMLInputCursorState,
+} from "@udecode/plate-combobox";
+import {
+  type TElement,
+  createPointRef,
+  findNodePath,
+  getPointBefore,
+  insertText,
+  moveSelection,
+  useComposedRef,
+  useEditorRef,
+} from "@udecode/plate-common";
+import { cva } from "class-variance-authority";
+
+type FilterFn = (
+  item: { keywords?: string[]; value: string },
+  search: string,
+) => boolean;
+
+interface InlineComboboxContextValue {
+  filter: FilterFn | false;
+  inputProps: UseComboboxInputResult["props"];
+  inputRef: RefObject<HTMLInputElement>;
+  removeInput: UseComboboxInputResult["removeInput"];
+  setHasEmpty: (hasEmpty: boolean) => void;
+  showTrigger: boolean;
+  trigger: string;
+}
+
+const InlineComboboxContext = createContext<InlineComboboxContextValue>(
+  null as any,
+);
+
+export const defaultFilter: FilterFn = ({ keywords = [], value }, search) =>
+  [value, ...keywords].some((keyword) => filterWords(keyword, search));
+
+interface InlineComboboxProps {
+  children: ReactNode;
+  element: TElement;
+  trigger: string;
+  filter?: FilterFn | false;
+  hideWhenNoValue?: boolean;
+  setValue?: (value: string) => void;
+  showTrigger?: boolean;
+  value?: string;
+}
+
+const InlineCombobox = ({
+  children,
+  element,
+  filter = defaultFilter,
+  hideWhenNoValue = false,
+  setValue: setValueProp,
+  showTrigger = true,
+  trigger,
+  value: valueProp,
+}: InlineComboboxProps) => {
+  const editor = useEditorRef();
+  const inputRef = React.useRef<HTMLInputElement>(null);
+  const cursorState = useHTMLInputCursorState(inputRef);
+
+  const [valueState, setValueState] = useState("");
+  const hasValueProp = valueProp !== undefined;
+  const value = hasValueProp ? valueProp : valueState;
+
+  const setValue = useCallback(
+    (newValue: string) => {
+      setValueProp?.(newValue);
+
+      if (!hasValueProp) {
+        setValueState(newValue);
+      }
+    },
+    [setValueProp, hasValueProp],
+  );
+
+  /**
+   * Track the point just before the input element so we know where to
+   * insertText if the combobox closes due to a selection change.
+   */
+  const [insertPoint, setInsertPoint] = useState<PointRef | null>(null);
+
+  useEffect(() => {
+    const path = findNodePath(editor, element);
+
+    if (!path) return;
+
+    const point = getPointBefore(editor, path);
+
+    if (!point) return;
+
+    const pointRef = createPointRef(editor, point);
+    setInsertPoint(pointRef);
+
+    return () => {
+      pointRef.unref();
+    };
+  }, [editor, element]);
+
+  const { props: inputProps, removeInput } = useComboboxInput({
+    cancelInputOnBlur: false,
+    cursorState,
+    onCancelInput: (cause) => {
+      if (cause !== "backspace") {
+        insertText(editor, trigger + value, {
+          at: insertPoint?.current ?? undefined,
+        });
+      }
+      if (cause === "arrowLeft" || cause === "arrowRight") {
+        moveSelection(editor, {
+          distance: 1,
+          reverse: cause === "arrowLeft",
+        });
+      }
+    },
+    ref: inputRef,
+  });
+
+  const [hasEmpty, setHasEmpty] = useState(false);
+
+  const contextValue: InlineComboboxContextValue = useMemo(
+    () => ({
+      filter,
+      inputProps,
+      inputRef,
+      removeInput,
+      setHasEmpty,
+      showTrigger,
+      trigger,
+    }),
+    [
+      trigger,
+      showTrigger,
+      filter,
+      inputRef,
+      inputProps,
+      removeInput,
+      setHasEmpty,
+    ],
+  );
+
+  const store = useComboboxStore({
+    // open: ,
+    setValue: (newValue) => startTransition(() => setValue(newValue)),
+  });
+
+  const items = store.useState("items");
+
+  useEffect;
+
+  /**
+   * If there is no active ID and the list of items changes, select the first
+   * item.
+   */
+  useEffect(() => {
+    if (!store.getState().activeId) {
+      store.setActiveId(store.first());
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [items, store]);
+
+  return (
+    <span contentEditable={false}>
+      <ComboboxProvider
+        open={
+          (items.length > 0 || hasEmpty) &&
+          (!hideWhenNoValue || value.length > 0)
+        }
+        store={store}
+      >
+        <InlineComboboxContext.Provider value={contextValue}>
+          {children}
+        </InlineComboboxContext.Provider>
+      </ComboboxProvider>
+    </span>
+  );
+};
+
+const InlineComboboxInput = forwardRef<
+  HTMLInputElement,
+  HTMLAttributes<HTMLInputElement>
+>(({ className, ...props }, propRef) => {
+  const {
+    inputProps,
+    inputRef: contextRef,
+    showTrigger,
+    trigger,
+  } = useContext(InlineComboboxContext);
+
+  const store = useComboboxContext()!;
+  const value = store.useState("value");
+
+  const ref = useComposedRef(propRef, contextRef);
+
+  /**
+   * To create an auto-resizing input, we render a visually hidden span
+   * containing the input value and position the input element on top of it.
+   * This works well for all cases except when input exceeds the width of the
+   * container.
+   */
+
+  return (
+    <>
+      {showTrigger && trigger}
+
+      <span className="relative min-h-[1lh]">
+        <span
+          aria-hidden="true"
+          className="invisible overflow-hidden text-nowrap"
+        >
+          {value || "\u200B"}
+        </span>
+
+        <Combobox
+          autoSelect
+          className={cn(
+            "absolute left-0 top-0 size-full bg-transparent outline-none",
+            className,
+          )}
+          ref={ref}
+          value={value}
+          {...inputProps}
+          {...props}
+        />
+      </span>
+    </>
+  );
+});
+
+InlineComboboxInput.displayName = "InlineComboboxInput";
+
+const InlineComboboxContent: typeof ComboboxPopover = ({
+  className,
+  ...props
+}) => {
+  // Portal prevents CSS from leaking into popover
+  return (
+    <Portal>
+      <ComboboxPopover
+        className={cn(
+          "z-[500] max-h-[288px] w-[300px] overflow-y-auto rounded-md bg-popover shadow-md",
+          className,
+        )}
+        {...props}
+      />
+    </Portal>
+  );
+};
+
+const comboboxItemVariants = cva(
+  "relative flex h-9 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none",
+  {
+    defaultVariants: {
+      interactive: true,
+    },
+    variants: {
+      interactive: {
+        false: "",
+        true: "cursor-pointer transition-colors hover:bg-accent hover:text-accent-foreground data-[active-item=true]:bg-accent data-[active-item=true]:text-accent-foreground",
+      },
+    },
+  },
+);
+
+export type InlineComboboxItemProps = {
+  keywords?: string[];
+} & ComboboxItemProps &
+  Required<Pick<ComboboxItemProps, "value">>;
+
+const InlineComboboxItem = ({
+  className,
+  keywords,
+  onClick,
+  ...props
+}: InlineComboboxItemProps) => {
+  const { value } = props;
+
+  const { filter, removeInput } = useContext(InlineComboboxContext);
+
+  const store = useComboboxContext()!;
+
+  // Optimization: Do not subscribe to value if filter is false
+  const search = filter && store.useState("value");
+
+  const visible = useMemo(
+    () => !filter || filter({ keywords, value }, search as string),
+    [filter, value, keywords, search],
+  );
+
+  if (!visible) return null;
+
+  return (
+    <ComboboxItem
+      className={cn(comboboxItemVariants(), className)}
+      onClick={(event) => {
+        removeInput(true);
+        onClick?.(event);
+      }}
+      {...props}
+    />
+  );
+};
+
+const InlineComboboxEmpty = ({
+  children,
+  className,
+}: HTMLAttributes<HTMLDivElement>) => {
+  const { setHasEmpty } = useContext(InlineComboboxContext);
+  const store = useComboboxContext()!;
+  const items = store.useState("items");
+
+  useEffect(() => {
+    setHasEmpty(true);
+
+    return () => {
+      setHasEmpty(false);
+    };
+  }, [setHasEmpty]);
+
+  if (items.length > 0) return null;
+
+  return (
+    <div
+      className={cn(comboboxItemVariants({ interactive: false }), className)}
+    >
+      {children}
+    </div>
+  );
+};
+
+export {
+  InlineCombobox,
+  InlineComboboxContent,
+  InlineComboboxEmpty,
+  InlineComboboxInput,
+  InlineComboboxItem,
+};

--- a/src/views/edit/editor/features/note-linking/NoteLinkDropdown.tsx
+++ b/src/views/edit/editor/features/note-linking/NoteLinkDropdown.tsx
@@ -1,0 +1,144 @@
+import React, { useState } from "react";
+
+import { cn, withRef } from "@udecode/cn";
+import { PlateElement, PlateEditor } from "@udecode/plate-common";
+
+import {
+  InlineCombobox,
+  InlineComboboxContent,
+  InlineComboboxEmpty,
+  InlineComboboxInput,
+  InlineComboboxItem,
+} from "../../components/InlineCombobox";
+import { NOTE_LINK } from "./createNoteLinkDropdownPlugin";
+import { ELEMENT_NOTE_LINK, INoteLinkElement } from "./NoteLinkElement";
+
+import {
+  TMentionItemBase,
+  MentionOnSelectItem,
+  MentionPlugin,
+  TMentionElement,
+} from "@udecode/plate";
+
+import {
+  getPlugin,
+  insertNodes,
+  moveSelection,
+  getBlockAbove,
+  isEndPoint,
+  insertText,
+} from "@udecode/plate-common";
+import { SearchItem, SearchStore } from "../../../../documents/SearchStore";
+
+type Option = Pick<INoteLinkElement, "noteId" | "title" | "journalName">;
+
+/**
+ * When selecting an item, insert a "note link" to the selected note.
+ */
+const onSelect = (editor: PlateEditor, item: Option) => {
+  // Get the parent createNoteRefPlugin
+  const {
+    options: { insertSpaceAfterMention },
+    type,
+  } = getPlugin<MentionPlugin>(editor as any, NOTE_LINK);
+
+  // Inlined (and de-paramaterized) from createMentionNode
+  const props = {
+    title: item.title,
+    noteId: item.noteId,
+    journalName: item.journalName,
+  };
+
+  insertNodes<INoteLinkElement>(editor, {
+    children: [{ text: item.title }],
+    type: ELEMENT_NOTE_LINK,
+    ...props,
+  } as INoteLinkElement);
+
+  // move the selection after the element
+  moveSelection(editor, { unit: "offset" });
+
+  const pathAbove = getBlockAbove(editor)?.[1];
+
+  const isBlockEnd =
+    editor.selection &&
+    pathAbove &&
+    isEndPoint(editor, editor.selection.anchor, pathAbove);
+
+  if (isBlockEnd && insertSpaceAfterMention) {
+    insertText(editor, " ");
+  }
+};
+
+// Convert document response objects into options for the dropdown
+function toOptions(
+  docs: SearchItem[],
+): Pick<INoteLinkElement, "title" | "journalName" | "noteId">[] {
+  return docs.slice(0, 10).map((d) => ({
+    noteId: d.id,
+    title: d.title || d.id,
+    journalName: d.journalId,
+  }));
+}
+
+/**
+ * A dropdown element, triggered by the "@" character, that searches notes.
+ * On select, insert a link ("note link") to the note.
+ */
+export const NoteLinkDropdownElement = withRef<typeof PlateElement>(
+  ({ className, ...props }, ref) => {
+    const { children, editor, element, store } = props as typeof props & {
+      // todo: Use a dedicated store, or a (type) sub-set of the SearchStore
+      store: SearchStore;
+    };
+
+    const [search, setSearch] = useState("");
+
+    React.useEffect(() => {
+      // todo: leading debounce; build into the store itself
+      store.setSearch([`title:${search}`]);
+    }, [search]);
+
+    return (
+      <PlateElement
+        as="span"
+        data-slate-value={element.value}
+        ref={ref}
+        {...props}
+      >
+        <InlineCombobox
+          element={element}
+          setValue={setSearch}
+          showTrigger={false}
+          trigger="@"
+          value={search}
+        >
+          <span
+            className={cn(
+              "inline-block rounded-md bg-muted px-1.5 py-0.5 align-baseline text-sm ring-ring focus-within:ring-2",
+              className,
+            )}
+          >
+            <InlineComboboxInput />
+          </span>
+
+          <InlineComboboxContent className="my-1.5">
+            <InlineComboboxEmpty>No results found</InlineComboboxEmpty>
+
+            {toOptions(store.docs).map((item) => (
+              <InlineComboboxItem
+                key={item.noteId}
+                onClick={() => onSelect(editor, item)}
+                value={item.title}
+              >
+                {item.title}
+              </InlineComboboxItem>
+            ))}
+          </InlineComboboxContent>
+        </InlineCombobox>
+
+        {children}
+      </PlateElement>
+    );
+  },
+);

--- a/src/views/edit/editor/features/note-linking/NoteLinkElement.tsx
+++ b/src/views/edit/editor/features/note-linking/NoteLinkElement.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { cn, withRef } from "@udecode/cn";
+import { useElement, PlateElement, TElement } from "@udecode/plate-common";
+import { useNavigate } from "react-router-dom";
+
+export const ELEMENT_NOTE_LINK = "noteLinkElement";
+
+export interface INoteLinkElement extends TElement {
+  title: string;
+  noteId: string;
+  journalName: string;
+}
+
+export const NoteLinkElement = withRef<typeof PlateElement>(
+  ({ className, children, ...props }, ref) => {
+    const navigate = useNavigate();
+    const element = useElement<INoteLinkElement>();
+
+    function edit(e: React.MouseEvent) {
+      e.preventDefault();
+      navigate(`/documents/edit/${element.noteId}`);
+    }
+
+    return (
+      <PlateElement
+        ref={ref}
+        asChild
+        className={cn(
+          "text-indigo-800 cursor-pointer underline underline-offset-1 decoration-1",
+          className,
+        )}
+        {...props}
+      >
+        <a onClick={edit}>{children}</a>
+      </PlateElement>
+    );
+  },
+);

--- a/src/views/edit/editor/features/note-linking/createNoteLinkDropdownPlugin.tsx
+++ b/src/views/edit/editor/features/note-linking/createNoteLinkDropdownPlugin.tsx
@@ -1,0 +1,93 @@
+import { createPluginFactory } from "@udecode/plate-core";
+import {
+  type PlateEditor,
+  type TElement,
+  getEditorString,
+  getPointBefore,
+  getRange,
+  getPluginOptions,
+} from "@udecode/plate-common";
+
+export const NOTE_LINK = "noteLinkingPlugin";
+
+interface NoteLinkPlugin {
+  triggerPreviousCharPattern?: RegExp;
+  triggerQuery?: (editor: PlateEditor) => boolean;
+}
+
+const TRIGGER = "@";
+const TRIGGER_PRIOR_PATTERN = /^\s?$/; // whitespace or beginning of line
+
+// Previously, trigger was an option, and could be a regex, string, or array of strings.
+const matchesTrigger = (text: string) => {
+  return text === TRIGGER;
+};
+
+/**
+ * Insert a note linking dropdown when "@" is typed.
+ *
+ * This plugin handles detecting the "@" character, inserting the dropdown,
+ * and injecting the search store into the dropdown.
+ *
+ * Adapated from MentionInput plugin and TriggerCombobox
+ * https://github.com/udecode/plate/blob/main/packages/combobox/src/withTriggerCombobox.ts
+ */
+export const createNoteLinkDropdownPlugin = createPluginFactory<NoteLinkPlugin>(
+  {
+    key: NOTE_LINK,
+
+    isVoid: true,
+    isInline: true,
+    // If false, when typing `@` neither the `@` symbol nor the dropdown will appear.
+    isElement: true,
+
+    // Can't use props directly, because we won't have a store reference
+    // props: ...
+    // Instead we can do this:
+    then: (editor, { options }: any) => {
+      // Docs suggest this, but it was not working :shrug:
+      // const options = getPluginOptions<any>(editor, NOTE_LINK);
+
+      // Store is injected to this plugin in <PlateContainer>;
+      // Forward to dropdown by injecting into options here.
+      // Maybe using context would be better?
+      return {
+        props: {
+          store: options.store,
+        },
+      };
+    },
+
+    withOverrides: (editor) => {
+      const { insertText } = editor;
+
+      editor.insertText = (text) => {
+        if (!editor.selection || !matchesTrigger(text)) {
+          return insertText(text);
+        }
+
+        // Only insert the dropdown if the previous character is a space or beginning of line
+        const previousChar = getEditorString(
+          editor,
+          getRange(
+            editor,
+            editor.selection,
+            getPointBefore(editor, editor.selection),
+          ),
+        );
+
+        if (TRIGGER_PRIOR_PATTERN?.test(previousChar)) {
+          return editor.insertNode({
+            type: NOTE_LINK,
+            trigger: text,
+            children: [{ text: "" }],
+          });
+        }
+
+        return insertText(text);
+      };
+
+      return editor;
+    },
+  },
+);

--- a/src/views/edit/editor/features/note-linking/createNoteLinkElementPlugin.tsx
+++ b/src/views/edit/editor/features/note-linking/createNoteLinkElementPlugin.tsx
@@ -1,0 +1,9 @@
+import { createPluginFactory } from "@udecode/plate-common";
+
+import { ELEMENT_NOTE_LINK } from "./NoteLinkElement";
+
+export const createNoteLinkElementPlugin = createPluginFactory({
+  isElement: true,
+  isInline: true,
+  key: ELEMENT_NOTE_LINK,
+});

--- a/src/views/edit/editor/features/note-linking/index.ts
+++ b/src/views/edit/editor/features/note-linking/index.ts
@@ -1,0 +1,13 @@
+export { NoteLinkDropdownElement } from "./NoteLinkDropdown";
+export {
+  createNoteLinkDropdownPlugin,
+  NOTE_LINK,
+} from "./createNoteLinkDropdownPlugin";
+export { createNoteLinkElementPlugin } from "./createNoteLinkElementPlugin";
+export {
+  NoteLinkElement,
+  INoteLinkElement,
+  ELEMENT_NOTE_LINK,
+} from "./NoteLinkElement";
+
+export { toMdastLinkFactory as createLinkFromNoteLinkFactory } from "./toMdast";

--- a/src/views/edit/editor/features/note-linking/toMdast.ts
+++ b/src/views/edit/editor/features/note-linking/toMdast.ts
@@ -1,0 +1,76 @@
+import { ELEMENT_NOTE_LINK, INoteLinkElement } from "./NoteLinkElement";
+import * as mdast from "../../../../../markdown/remark-slate-transformer/models/mdast";
+import { Node } from "../../../../../markdown/remark-slate-transformer/models/slate";
+
+/**
+ * Convert a NoteLinkElement to a standard MDAST link (i.e. Slate -> MDAST).
+ *
+ * NoteLink's are only special in that they link to another note, i.e. .md rather
+ * than a URL. So when we encode them to markdown, can just treat them as a standard
+ * (file) link. Note that _how_ they are encoded is tightly coupled to the feature, because
+ * we expect to parse them back into NoteLinkElements.
+ */
+export function toMdastLinkFactory(convertNodes: (nodes: Node[]) => any) {
+  return function toMdastLink(node: INoteLinkElement): mdast.Link {
+    const { title, noteId, journalName, children } = node;
+
+    // NOTE: This format assumes if notes were exported, the format of all notes would be
+    // <somedir>/<journal_id>/<note_id>.md. While intra-journal linking could be simplified
+    // to ./<note_id>.md, then we would need to update the links if the note was changed to
+    // a different journal (which I do constantly).
+    const url = `../${journalName}/${noteId}.md`;
+
+    return {
+      type: "link",
+      url,
+      title,
+      children: convertNodes(children), // as any as mdast.Link["children"],
+    } as any;
+  };
+}
+
+// For parsing note links, i.e. the `./<journalId>/<noteId>.md` format.
+const noteLinkRegex = /^\..\/(?:(.+)\/)?([a-zA-Z0-9-]+)\.md$/;
+
+// Embedded within
+export function checkNoteLink(url: string) {
+  if (!url) return null;
+
+  const match = url.match(noteLinkRegex);
+  const journalName = match ? match[1] : null;
+  const noteId = match ? match[2] : null;
+  if (!noteId || !journalName) return null;
+  return { noteId, journalName };
+}
+
+interface ToSlateLink {
+  url: string;
+  convertNodes: any;
+  deco: any;
+  children: any;
+}
+
+export function toSlateLink({
+  url,
+  convertNodes,
+  deco,
+  children,
+}: ToSlateLink) {
+  const res = checkNoteLink(url);
+
+  if (res) {
+    return {
+      type: ELEMENT_NOTE_LINK,
+      children: convertNodes(children, deco),
+      title: "",
+      // note: url is unused by NoteLinkElement, but the TS interface of Slate's link DOM
+      // is declared as Link = ReturnType<typeof createLink>, so returning something different
+      // here (i.e. omitting url) messed up that type. Technically we could return url here and
+      // have the NoteLinkElement parse out the URL... but we have to detect type: ELEMENT_NOTE_LINK
+      // here anyways so...
+      url,
+      noteId: res.noteId,
+      journalName: res.journalName,
+    };
+  }
+}

--- a/src/views/edit/editor/plugins/createInlineEscapePlugin.ts
+++ b/src/views/edit/editor/plugins/createInlineEscapePlugin.ts
@@ -1,0 +1,68 @@
+import { createPluginFactory } from "@udecode/plate-core";
+
+// These are all effectively overrides of Slate Editor.blah methods, sometimes re-named,
+// usually handling Plate types and doing inline null checking
+import {
+  isInline,
+  getAboveNode,
+  isEndPoint,
+  getPointAfter,
+  setSelection,
+} from "@udecode/plate-common";
+import { Editor, Range, Transforms } from "slate";
+
+const KEY_INLINE_ESCAPE = "inline-escape";
+
+/**
+ * Escape an inline element (ex: Link editing) when the cursor is at the end.
+ *
+ * This is required to escape from link or note link editing when at the end of the "inline" element.
+ * It does mean if you want to edit the end of text, or add spaces, that you have to move the cursor
+ * inisde the element, edit as needed, then delete the end, but this is common in many editors.
+ *
+ * It may make sense to do something more sophisticated eventually, see the below for context:
+ *
+ * Built in to Slate: https://github.com/ianstormtaylor/slate/pull/3260
+ * Removed from Slate (reverts ^): https://github.com/ianstormtaylor/slate/pull/4578
+ * Advanced example: https://github.com/ianstormtaylor/slate/pull/4615
+ * (Active issue) strongly related to ^: https://github.com/ianstormtaylor/slate/issues/4704
+ */
+export const createInlineEscapePlugin = createPluginFactory({
+  key: KEY_INLINE_ESCAPE,
+  isVoid: true,
+  withOverrides: (editor) => {
+    const { insertText } = editor;
+
+    editor.insertText = (text) => {
+      const { selection } = editor;
+
+      if (selection) {
+        const { anchor } = selection;
+
+        // Check if the selection is collapsed and at the end of an inline
+        if (Range.isCollapsed(selection)) {
+          const inline = getAboveNode(editor, {
+            match: (n) => isInline(editor, n),
+          });
+
+          if (inline) {
+            const [, inlinePath] = inline;
+
+            // If the cursor is at the end of the inline, move it outside
+            if (isEndPoint(editor, anchor, inlinePath)) {
+              const point = getPointAfter(editor, inlinePath);
+              if (point) {
+                setSelection(editor, { anchor: point, focus: point });
+              }
+            }
+          }
+        }
+      }
+
+      // Call the original insertText method
+      insertText(text);
+    };
+
+    return editor;
+  },
+});

--- a/src/views/edit/editor/plugins/createResetNodePlugin/createResetNodePlugin.ts
+++ b/src/views/edit/editor/plugins/createResetNodePlugin/createResetNodePlugin.ts
@@ -1,0 +1,101 @@
+import {
+  type TElement,
+  createPluginFactory,
+  getEndPoint,
+  getNode,
+  getNodeProps,
+  getStartPoint,
+  isCollapsed,
+  resetEditorChildren,
+  setNodes,
+  unsetNodes,
+  withoutNormalizing,
+} from "@udecode/plate-common";
+import { Point } from "slate";
+
+import type { ResetNodePlugin } from "./types";
+
+import { onKeyDownResetNode } from "./onKeyDownResetNode";
+
+export const KEY_RESET_NODE = "resetNode";
+
+/**
+ * Support resetting block types.
+ *
+ * Copied from Plate (MIT) to support some logging / debugging; does not work as expected on
+ * block quotes; so leaving here so we can modify and click-to-source code at will; assuming
+ * we will modify this at some point. If not, we can remove it.
+ */
+export const createResetNodePlugin = createPluginFactory<ResetNodePlugin>({
+  handlers: {
+    onKeyDown: onKeyDownResetNode,
+  },
+  key: KEY_RESET_NODE,
+  options: {
+    rules: [],
+  },
+  withOverrides: (editor, { options }) => {
+    const { deleteBackward, deleteFragment } = editor;
+
+    if (!options.disableEditorReset) {
+      const deleteFragmentPlugin = () => {
+        const { selection } = editor;
+
+        if (!selection) return;
+
+        const start = getStartPoint(editor, []);
+        const end = getEndPoint(editor, []);
+
+        if (
+          (Point.equals(selection.anchor, start) &&
+            Point.equals(selection.focus, end)) ||
+          (Point.equals(selection.focus, start) &&
+            Point.equals(selection.anchor, end))
+        ) {
+          resetEditorChildren(editor, {
+            insertOptions: { select: true },
+          });
+
+          return true;
+        }
+      };
+
+      editor.deleteFragment = (direction) => {
+        if (deleteFragmentPlugin()) return;
+
+        deleteFragment(direction);
+      };
+    }
+    if (!options.disableFirstBlockReset) {
+      editor.deleteBackward = (unit) => {
+        const { selection } = editor;
+
+        if (selection && isCollapsed(selection)) {
+          const start = getStartPoint(editor, []);
+
+          if (Point.equals(selection.anchor, start)) {
+            const node = getNode<TElement>(editor, [0])!;
+
+            const { children, ...props } = editor.blockFactory({}, [0]);
+
+            // replace props
+            withoutNormalizing(editor, () => {
+              // unsetNodes(editor, Object.keys(getNodeProps(node)), { at: [0] });
+              // missing id will cause block selection not working and other issues
+              const { id, ...nodeProps } = getNodeProps(node);
+
+              unsetNodes(editor, Object.keys(nodeProps), { at: [0] });
+              setNodes(editor, props, { at: [0] });
+            });
+
+            return;
+          }
+        }
+
+        deleteBackward(unit);
+      };
+    }
+
+    return editor;
+  },
+});

--- a/src/views/edit/editor/plugins/createResetNodePlugin/index.ts
+++ b/src/views/edit/editor/plugins/createResetNodePlugin/index.ts
@@ -1,0 +1,1 @@
+export * from "./createResetNodePlugin";

--- a/src/views/edit/editor/plugins/createResetNodePlugin/onKeyDownResetNode.ts
+++ b/src/views/edit/editor/plugins/createResetNodePlugin/onKeyDownResetNode.ts
@@ -1,0 +1,52 @@
+import {
+  type KeyboardHandlerReturnType,
+  type PlateEditor,
+  type Value,
+  type WithPlatePlugin,
+  isCollapsed,
+  isHotkey,
+  setElements,
+  someNode,
+} from "@udecode/plate-common";
+
+import type { ResetNodePlugin } from "./types";
+
+export const SIMULATE_BACKSPACE: any = {
+  key: "",
+  which: 8,
+};
+
+export const onKeyDownResetNode =
+  <V extends Value = Value, E extends PlateEditor<V> = PlateEditor<V>>(
+    editor: E,
+    { options: { rules } }: WithPlatePlugin<ResetNodePlugin, V, E>,
+  ): KeyboardHandlerReturnType =>
+  (event) => {
+    if (event.defaultPrevented) return;
+
+    let reset;
+
+    if (!editor.selection) return;
+    if (isCollapsed(editor.selection)) {
+      rules!.forEach(({ defaultType, hotkey, onReset, predicate, types }) => {
+        if (
+          hotkey &&
+          isHotkey(hotkey, event as any) &&
+          predicate(editor as any) &&
+          someNode(editor, { match: { type: types } })
+        ) {
+          event.preventDefault?.();
+
+          setElements(editor, { type: defaultType });
+
+          if (onReset) {
+            onReset(editor as any);
+          }
+
+          reset = true;
+        }
+      });
+    }
+
+    return reset;
+  };

--- a/src/views/edit/editor/plugins/createResetNodePlugin/types.ts
+++ b/src/views/edit/editor/plugins/createResetNodePlugin/types.ts
@@ -1,0 +1,26 @@
+import type { HotkeyPlugin, PlateEditor, Value } from "@udecode/plate-common";
+
+export interface ResetNodePluginRule<
+  V extends Value = Value,
+  E extends PlateEditor<V> = PlateEditor<V>,
+> extends HotkeyPlugin {
+  /** Additional condition to the rule. */
+  predicate: (editor: E) => boolean;
+
+  /** Node types where the rule applies. */
+  types: string[];
+
+  defaultType?: string;
+
+  /** Callback called when resetting. */
+  onReset?: (editor: E) => void;
+}
+
+export interface ResetNodePlugin<
+  V extends Value = Value,
+  E extends PlateEditor<V> = PlateEditor<V>,
+> {
+  disableEditorReset?: boolean;
+  disableFirstBlockReset?: boolean;
+  rules?: ResetNodePluginRule<V, E>[];
+}

--- a/src/views/edit/index.tsx
+++ b/src/views/edit/index.tsx
@@ -19,13 +19,17 @@ import { Separator } from "./editor/components/Separator";
 import * as Base from "../layout";
 
 // Loads document, with loading and error placeholders
-function DocumentLoadingContainer() {
+const DocumentLoadingContainer = observer(() => {
   const journalsStore = useContext(JournalsStoreContext)!;
   const { document: documentId } = useParams();
 
   // todo: handle missing or invalid documentId; loadingError may be fine for this, but
   // haven't done any UX / design thinking around it.
-  const { document, loadingError } = useEditableDocument(documentId!);
+  const {
+    document,
+    error: loadingError,
+    loading,
+  } = useEditableDocument(documentId!);
 
   // Filter journals to non-archived ones, but must also add
   // the current document's journal if its archived
@@ -45,17 +49,18 @@ function DocumentLoadingContainer() {
     setJournals(journals);
   }, [document, loadingError]);
 
-  // todo: I don't hit this error when going back and forth to a deleted document, why doesn't this happen?
   if (loadingError) {
     return <EditLoadingComponent error={loadingError} />;
   }
 
-  if (!document || !journals) {
+  // `loading` acts as a break when navigating from one document to another, effectively
+  // resetting the state of the editor
+  if (!document || !journals || loading) {
     return <EditLoadingComponent />;
   }
 
   return <DocumentEditView document={document} journals={journals} />;
-}
+});
 
 interface DocumentEditProps {
   document: EditableDocument;
@@ -168,4 +173,4 @@ const DocumentEditView = observer((props: DocumentEditProps) => {
   );
 });
 
-export default observer(DocumentLoadingContainer);
+export default DocumentLoadingContainer;

--- a/src/views/edit/loading.tsx
+++ b/src/views/edit/loading.tsx
@@ -32,9 +32,7 @@ export const EditLoadingComponent = observer((props: LoadingComponentProps) => {
       </Titlebar>
       <Pane padding={50} paddingTop={98} flexGrow={1} display="flex">
         <Pane flexGrow={1} display="flex" flexDirection="column" width="100%">
-          <Pane flexGrow={1} paddingTop={24}>
-            <h3>Coming soon...</h3>
-          </Pane>
+          <Pane flexGrow={1} paddingTop={24}></Pane>
         </Pane>
       </Pane>
     </>

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,6 +7,27 @@
   resolved "https://registry.yarnpkg.com/@alloc/quick-lru/-/quick-lru-5.2.0.tgz#7bf68b20c0a350f936915fcae06f58e32007ce30"
   integrity sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==
 
+"@ariakit/core@0.4.8":
+  version "0.4.8"
+  resolved "https://registry.yarnpkg.com/@ariakit/core/-/core-0.4.8.tgz#83e8576e89baacf769cab506c63a672b3a4581d4"
+  integrity sha512-HQS+9CI7pMqqVlAt5bPGenT0/e65UxXY+PKtgU7Y+0UToBDBRolO5S9+UUSDm8OmJHSnq24owEGm1Mv28l5XCQ==
+
+"@ariakit/react-core@0.4.8":
+  version "0.4.8"
+  resolved "https://registry.yarnpkg.com/@ariakit/react-core/-/react-core-0.4.8.tgz#448b0567b43a7ebabb892aaf0283ff1d074e8be8"
+  integrity sha512-TzsddUWQwWYhrEVWHA/Gf7KCGx8rwFohAHfuljjqidKeZi2kUmuRAImCTG9oga34FWHFf4AdXQbBKclMNt0nrQ==
+  dependencies:
+    "@ariakit/core" "0.4.8"
+    "@floating-ui/dom" "^1.0.0"
+    use-sync-external-store "^1.2.0"
+
+"@ariakit/react@^0.4.8":
+  version "0.4.8"
+  resolved "https://registry.yarnpkg.com/@ariakit/react/-/react-0.4.8.tgz#ede99942d69c7234b9f9f98ba47b252ea256c29a"
+  integrity sha512-Bb1vOrp0X52hxi1wE9TEHjjZ/Y08tVq2ZH+RFDwRQB3g04uVwrrhnTccHepC6rsObrDpAOV3/YlJCi4k/lSUaQ==
+  dependencies:
+    "@ariakit/react-core" "0.4.8"
+
 "@babel/code-frame@^7.23.5":
   version "7.23.5"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.23.5.tgz#9009b69a8c602293476ad598ff53e4562e15c244"
@@ -470,6 +491,14 @@
   dependencies:
     "@floating-ui/utils" "^0.2.1"
 
+"@floating-ui/dom@^1.0.0":
+  version "1.6.10"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.6.10.tgz#b74c32f34a50336c86dcf1f1c845cf3a39e26d6f"
+  integrity sha512-fskgCFv8J8OamCmyun8MfjB1Olfn+uZKjOKZ0vhYF3gRmEUXcGOjxWL8bBr7i4kIuPZ2KD2S3EUIOxnjC8kl2A==
+  dependencies:
+    "@floating-ui/core" "^1.6.0"
+    "@floating-ui/utils" "^0.2.7"
+
 "@floating-ui/dom@^1.2.1":
   version "1.6.5"
   resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.6.5.tgz#323f065c003f1d3ecf0ff16d2c2c4d38979f4cb9"
@@ -518,6 +547,11 @@
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.1.tgz#16308cea045f0fc777b6ff20a9f25474dd8293d2"
   integrity sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q==
+
+"@floating-ui/utils@^0.2.7":
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.7.tgz#d0ece53ce99ab5a8e37ebdfe5e32452a2bfc073e"
+  integrity sha512-X8R8Oj771YRl/w+c1HqAC1szL8zWQRwFvgDwT129k9ACdBoud/+/rX9V0qiMl6LWUdP9voC2nDVZYPMQQsb6eA==
 
 "@gar/promisify@^1.1.3":
   version "1.1.3"
@@ -6756,6 +6790,11 @@ use-sync-external-store@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
   integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
+
+use-sync-external-store@^1.2.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz#c3b6390f3a30eba13200d2302dcdf1e7b57b2ef9"
+  integrity sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==
 
 util-deprecate@^1.0.1, util-deprecate@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Add linking from one note to another.  Uses the `@` symbol to trigger the dropdown menu, which provides note search functionality. On selecting a note, copy a reference to it, serialized as a link in the form of `../<journal_id>/<note_id>.md`. The menu looks like:

<img width="339" alt="Screenshot 2024-09-01 at 3 51 40 PM" src="https://github.com/user-attachments/assets/d470b527-9431-48f7-adfe-566b3115d893">


When selecting an item, link will be embedded into the note; I ended up changing the color slightly to indicate its a note link. Did not put a ton of thought into the design here, want to use it in anger to organize my thoughts on it.

<img width="207" alt="Screenshot 2024-09-01 at 3 52 21 PM" src="https://github.com/user-attachments/assets/87e5b24a-6929-407c-b1bf-9dfaf0a8ddd6">


A couple of notes on some of the design choices:

- Link format: Should be safe whether note is linked to same or different journal, and assumes a future export structure of `<notesdir>/<journal_id>/<note_id>`. 
- ariakit: Time was the most constrained yet the last month, so I grabbed examples that were closest to working and ran with it. Follow-up work is already planned to organize all comboboxes, so will naturally clean-up and make things consistent there
- Inlined a few Plate components w/ some modifications: I find code diving esp. with changing versions very difficult to debug, and also found it easier to fully fork / customize. Longer term I think design will drift substantially, so probably better to start inlining. Did not put much work into organizing and will rely on future refactoring, esp. once I better understand Slate architecture, to clean it all up 

Closes #124 

Follow-up work:
- https://github.com/cloverich/chronicles/issues/226
- https://github.com/cloverich/chronicles/issues/221 (added: Plan for ariakit combobox)
- https://github.com/cloverich/chronicles/issues/227
- https://github.com/cloverich/chronicles/issues/228