### PR TITLE
add starter license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+# License
+
+© Christopher Loverich 2024. All rights reserved.
+
+Please see https://github.com/cloverich/chronicles/issues/244
+
+This project is "source available," meaning the source code is viewable but not open for use, modification, or distribution.
+
+All rights are reserved by the author. Usage of this code without explicit permission is prohibited.
+
+## Contributions
+
+By contributing to this repository, you agree to a Contributor License Agreement (CLA), transferring all rights of your contributions to the author. This means the author retains the right to use, modify, and license your contributions as they see fit.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "chronicles",
   "version": "1.0.0",
   "main": "main.bundle.js",
-  "license": "UNLICENSED",
   "scripts": {
     "build": "./build.sh",
     "lint": "yarn run lint:prettier:check && yarn run lint:types:check",


### PR DESCRIPTION
Add's a starter license with a CLA, and a pointer to [this placeholder issue ](https://github.com/cloverich/chronicles/issues/244) with the likely license directions I'll take the application. 