### PR TITLE
remove USER_FILES_DIR; fix upload; fix rootdir name

### DIFF
--- a/src/electron/index.js
+++ b/src/electron/index.js
@@ -21,13 +21,6 @@ const { ensureDir } = require("./ensureDir");
 initUserFilesDir(app.getPath("userData"));
 console.log("application settings at startup:", settings.store);
 
-const USER_FILES_DIR = settings.get("USER_FILES_DIR");
-if (!USER_FILES_DIR) {
-  throw new Error(
-    "USER_FILES_DIR missing in main tooo after calling initUserFilesDir",
-  );
-}
-
 const DATABASE_URL = "DATABASE_URL";
 
 // Used by createWindow, but needed in database routine because of the filepicker call

--- a/src/preload/client/files.ts
+++ b/src/preload/client/files.ts
@@ -88,7 +88,9 @@ export class FilesClient {
   };
 
   uploadFile = async (file: File): Promise<UploadResponse> => {
-    const dir = await this.settings.get("USER_FILES_DIR");
+    const chronRoot = (await this.settings.get("NOTES_DIR")) as string;
+    const dir = path.join(chronRoot, "_attachments");
+
     const ext = path.parse(file.name).ext;
     const filename = `${uuidv7()}${ext || ".unknown"}`;
     const filepath = path.join(dir as string, filename);
@@ -104,6 +106,30 @@ export class FilesClient {
         .on("close", () => res({ filename: filename }))
         .on("error", (err) => rej(err));
     });
+  };
+
+  /**
+   * The uploadImage option on plate's createImagesPlugin.
+   * @param dataUrl - It receives a dataurl after users drag and drop an image onto the editor of
+   *  the form: data:image/png;base64,iVBORw0KGg...
+   *
+   * todo: Actual signature is:  string | ArrayBuffer) => string | ArrayBuffer | Promise<string | ArrayBuffer>;
+   * but calling code definitely only sends a string. See implementation notes below, and also the
+   * createImagePlugin implementation
+   */
+  uploadImage = (dataUrl: string | ArrayBuffer) => {
+    // NOTE: At time of writing, the code that calls this is in plate at
+    // packages/media/src/image/withImageUpload.ts
+    // It receives a FileList, iterates it to get File objects, then does two things
+    // 1. if (mime === 'image')  -- so I don't need to check image type here
+    // 2. It calls reader.readAsDataURL(file); so IDK why the type signature is string | ArrayBuffer
+    // todo(perf): Eventually, should pull in the function and re-implement it the way I had previously,
+    // reading the data as ArrayBuffer and avoiding the need to encode to base64 only to immmediately
+    // decode...but for now this works, and images aren't copied and pasted into the editor that often
+    return this.upload(dataUrl as string).then((json: any) => {
+      // todo: ImageElement could check if image is local or remote; if local, prefix with chronicles://
+      return `chronicles://../_attachments/${json.filename}`;
+    }, console.error) as Promise<string>; // createImagePlugin doesn't allow Promise<void>
   };
 
   /**
@@ -131,30 +157,6 @@ export class FilesClient {
     const { docPath } = this.getSafeDocumentPath(journal, documentId);
 
     await fs.promises.unlink(docPath);
-  };
-
-  /**
-   * The uploadImage option on plate's createImagesPlugin.
-   * @param dataUrl - It receives a dataurl after users drag and drop an image onto the editor of
-   *  the form: data:image/png;base64,iVBORw0KGg...
-   *
-   * todo: Actual signature is:  string | ArrayBuffer) => string | ArrayBuffer | Promise<string | ArrayBuffer>;
-   * but calling code definitely only sends a string. See implementation notes below, and also the
-   * createImagePlugin implementation
-   */
-  uploadImage = (dataUrl: string | ArrayBuffer) => {
-    // NOTE: At time of writing, the code that calls this is in plate at
-    // packages/media/src/image/withImageUpload.ts
-    // It receives a FileList, iterates it to get File objects, then does two things
-    // 1. if (mime === 'image')  -- so I don't need to check image type here
-    // 2. It calls reader.readAsDataURL(file); so IDK why the type signature is string | ArrayBuffer
-    // todo(perf): Eventually, should pull in the function and re-implement it the way I had previously,
-    // reading the data as ArrayBuffer and avoiding the need to encode to base64 only to immmediately
-    // decode...but for now this works, and images aren't copied and pasted into the editor that often
-    return this.upload(dataUrl as string).then((json: any) => {
-      // todo: ImageElement could check if image is local or remote; if local, prefix with chronicles://
-      return `chronicles://../_attachments/${json.filename}`;
-    }, console.error) as Promise<string>; // createImagePlugin doesn't allow Promise<void>
   };
 
   renameFolder = async (oldName: string, newName: string) => {


### PR DESCRIPTION
- remove stale reference (and check) to USER_FILES_DIR
- fix upload (match upload / uploadFile to uploadImage)
- fix issue where when parent dir and journal had same name... the super intelligent sync routine would skip the journal, then choke when a document expected it to exist.

Good thing I have no users yet. 