### PR TITLE
add markdown/notion importer

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "chai": "^5.0.3",
     "class-variance-authority": "^0.7.0",
     "date-fns": "^3.3.1",
+    "deep-object-diff": "^1.1.9",
     "electron": "^28.2.0",
     "esbuild": "^0.20.0",
     "evergreen-ui": "^7.1.9",

--- a/src/electron/index.js
+++ b/src/electron/index.js
@@ -308,8 +308,9 @@ app.on("activate", () => {
 //   event.reply("preferences-updated");
 // });
 
-// Preferences in UI allows user to specify user files directory
-ipcMain.on("select-chronicles-root", async (event, arg) => {
+// Preferences in UI allows user to specify chronicles root
+// and imports directories
+ipcMain.on("select-directory", async (event, arg) => {
   if (!mainWindow) {
     console.error(
       "received request to open file picker but mainWindow is undefined",
@@ -325,26 +326,21 @@ ipcMain.on("select-chronicles-root", async (event, arg) => {
 
   // user selected cancel
   if (!filepath) {
-    event.reply("preferences-updated", {
-      name: "NOTES_DIR",
+    event.reply("directory-selected", {
       value: null,
       error: null,
     });
     return;
   }
 
-  // todo: feedback to user if error
-  // https://github.com/cloverich/chronicles/issues/52
   try {
     ensureDir(filepath);
-    settings.set("NOTES_DIR", filepath);
   } catch (err) {
     console.error(
       `Error accessing directory ${filepath}; canceling update to NOTES_DIR`,
       err,
     );
-    event.reply("preferences-updated", {
-      name: "NOTES_DIR",
+    event.reply("directory-selected", {
       value: null,
       error: `Error accessing directory ${filepath}; canceling update to NOTES_DIR`,
     });
@@ -352,8 +348,7 @@ ipcMain.on("select-chronicles-root", async (event, arg) => {
   }
 
   // NOTE: Do not change this name without updating UI handlers
-  event.reply("preferences-updated", {
-    name: "NOTES_DIR",
+  event.reply("directory-selected", {
     value: filepath,
     error: null,
   });

--- a/src/preload/client/documents.ts
+++ b/src/preload/client/documents.ts
@@ -224,11 +224,24 @@ updatedAt: ${document.updatedAt}
     return `${fm}\n\n${document.content}`;
   };
 
-  private createDocument = async (args: SaveRequest): Promise<string> => {
+  /**
+   * Create (upload) a new document and index it
+   * @param args - The document to create
+   * @param index - Whether to index the document - set to false when importing (we import, then call `sync` instead)
+   */
+  createDocument = async (
+    args: SaveRequest,
+    index: boolean = true,
+  ): Promise<string> => {
     const id = uuidv7();
     const content = this.contentsWithFrontMatter(args);
     await this.files.uploadDocument({ id, content }, args.journal);
-    return this.createIndex({ id, ...args });
+
+    if (index) {
+      return this.createIndex({ id, ...args });
+    } else {
+      return id;
+    }
   };
 
   private updateDocument = async (args: SaveRequest): Promise<void> => {

--- a/src/preload/client/importer.test.ts
+++ b/src/preload/client/importer.test.ts
@@ -1,0 +1,236 @@
+export const testCases = [
+  // Case 1: Title and simple front matter with no special characters
+  {
+    input: `# My First Note
+
+Created By: John Doe
+Last Edited: July 20, 2023 12:00 PM
+Category: personal
+createdAt: January 1, 2021
+published: Yes
+
+This is the body of the document.`,
+    expected: {
+      title: "My First Note",
+      frontMatter: {
+        CreatedBy: "John Doe",
+        LastEdited: "July 20, 2023 12:00 PM",
+        Category: "personal",
+        createdAt: "January 1, 2021",
+        published: "Yes",
+      },
+      body: "This is the body of the document.",
+    },
+  },
+
+  // Case 2: Title with no front matter
+  {
+    input: `# Another Note
+
+This document has no front matter, just content.`,
+    expected: {
+      title: "Another Note",
+      frontMatter: {},
+      body: "This document has no front matter, just content.",
+    },
+  },
+
+  // Case 3: No title, but front matter with special characters
+  {
+    input: `Created By: Jane Doe
+Last Edited: July 20, 2023 12:00 PM
+Category: "work, personal"
+createdAt: January 1, 2021 8:30 AM
+published: No
+
+Body starts here and has no title.`,
+    expected: {
+      title: "",
+      frontMatter: {
+        CreatedBy: "Jane Doe",
+        LastEdited: "July 20, 2023 12:00 PM",
+        Category: "work, personal",
+        createdAt: "January 1, 2021 8:30 AM",
+        published: "No",
+      },
+      body: "Body starts here and has no title.",
+    },
+  },
+
+  // Case 4: Title with front matter missing values
+  {
+    input: `# Empty Values
+Created By:
+Last Edited:
+Category: work
+createdAt:
+published:
+
+Content for this note goes here.`,
+    expected: {
+      title: "Empty Values",
+      frontMatter: {
+        CreatedBy: "",
+        LastEdited: "",
+        Category: "work",
+        createdAt: "",
+        published: "",
+      },
+      body: "Content for this note goes here.",
+    },
+  },
+
+  // Case 5: Title with multi-line front matter
+  // Nah. https://github.com/cloverich/chronicles/issues/256
+  //   {
+  //     input: `# Project Plan
+  // Created By: "Chris O"
+  // Last Edited: July 25, 2023 9:45 PM
+  // Category: project
+  // createdAt: February 15, 2021 10:30 AM
+  // description: >
+  //   This project plan outlines the goals and milestones
+  //   for the next quarter.
+
+  // The body of the project plan begins here.`,
+  //     expected: {
+  //       title: "Project Plan",
+  //       frontMatter: {
+  //         CreatedBy: "Chris O",
+  //         LastEdited: "July 25, 2023 9:45 PM",
+  //         Category: "project",
+  //         createdAt: "February 15, 2021 10:30 AM",
+  //         description:
+  //           "This project plan outlines the goals and milestones for the next quarter.",
+  //       },
+  //       body: "The body of the project plan begins here.",
+  //     },
+  //   },
+
+  // Case 6: YAML-style front matter with tags; no space after last line of
+  // front matter (but has correct ---)
+  {
+    input: `---
+title: "YAML Note"
+tags: work, personal
+createdAt: 2023-09-28
+updatedAt: 2023-09-29
+---
+This is a document with YAML front matter.`,
+    expected: {
+      title: "",
+      frontMatter: {
+        title: "YAML Note",
+        tags: ["work", "personal"],
+        createdAt: "2023-09-28",
+        updatedAt: "2023-09-29",
+      },
+      body: "This is a document with YAML front matter.",
+    },
+  },
+
+  // Case 7: YAML front matter without tags
+  {
+    input: `---
+title: "Note Without Tags"
+createdAt: 2023-09-28
+---
+Just some plain content.`,
+    expected: {
+      title: "",
+      frontMatter: {
+        title: "Note Without Tags",
+        createdAt: "2023-09-28",
+      },
+      body: "Just some plain content.",
+    },
+  },
+
+  // Case 8: No front matter or title, only body
+  {
+    input: `This document only has body content.`,
+    expected: {
+      title: "",
+      frontMatter: {},
+      body: "This document only has body content.",
+    },
+  },
+
+  // Case 9: Front matter with a multi-line description field
+  // https://github.com/cloverich/chronicles/issues/256
+  //   {
+  //     input: `# Notes on Testing
+  // Description: >
+  //   This document explains
+  //   the importance of testing
+  //   in software development.
+
+  // The body text starts here.`,
+  //     expected: {
+  //       title: "Notes on Testing",
+  //       frontMatter: {
+  //         Description:
+  //           "This document explains the importance of testing in software development.",
+  //       },
+  //       body: "The body text starts here.",
+  //     },
+  //   },
+
+  // Case 10: Mixed Notion-style front matter with YAML tags
+  {
+    input: `# Mixed Front Matter
+Created By: John Doe
+Last Edited: July 20, 2023
+tags: work, projects
+
+Body content follows after mixed front matter.`,
+    expected: {
+      title: "Mixed Front Matter",
+      frontMatter: {
+        CreatedBy: "John Doe",
+        LastEdited: "July 20, 2023",
+        tags: ["work", "projects"],
+      },
+      body: "Body content follows after mixed front matter.",
+    },
+  },
+
+  // Case 11: No front-matter, colon in the body
+  {
+    input: `# Notion title + colon in body
+
+Body content has a colon: in it!`,
+    expected: {
+      title: "Notion title + colon in body",
+      frontMatter: {},
+      body: "Body content has a colon: in it!",
+    },
+  },
+
+  // Case 12: No front-matter, colon in the body
+  {
+    input: `# Notion title + front matter + colon in body
+    
+Created By: John Doe
+Last Edited: July 20, 2023 12:00 PM
+Category: personal
+createdAt: January 1, 2021
+published: Yes
+
+Body content has a colon: in it!`,
+    expected: {
+      title: "Notion title + front matter + colon in body",
+      frontMatter: {
+        CreatedBy: "John Doe",
+        LastEdited: "July 20, 2023 12:00 PM",
+        Category: "personal",
+        createdAt: "January 1, 2021",
+        published: "Yes",
+      },
+      body: "Body content has a colon: in it!",
+    },
+  },
+];
+
+// todo: Test with colons in the body, ensure it STOPS trying tp parse front matter
+// after the final newline; either that or pre-process the content to ...

--- a/src/preload/client/importer.ts
+++ b/src/preload/client/importer.ts
@@ -1,0 +1,416 @@
+import { Database } from "better-sqlite3";
+import { diff } from "deep-object-diff";
+import { Knex } from "knex";
+import path from "path";
+import yaml from "yaml";
+import { Files } from "../files";
+import { IDocumentsClient } from "./documents";
+import { IFilesClient } from "./files";
+import { IJournalsClient } from "./journals";
+import { IPreferencesClient } from "./preferences";
+import { ISyncClient } from "./sync";
+
+export type IImporterClient = ImporterClient;
+
+import { testCases } from "./importer.test";
+
+// Temporary helper to test frontmatter parsing and dump the results
+// to the console; can convert to real tests at the end.
+export function runFrontmatterTests() {
+  for (const testCase of testCases) {
+    console.log("TEST:", testCase.expected.title);
+    const result = parseTitleAndFrontMatter(testCase.input);
+    if (!result.frontMatter) {
+      console.info("FAILED: no front matter");
+      console.info(testCase.input);
+      break;
+    } else {
+      if (result.title !== testCase.expected.title) {
+        console.error("FAILED: title");
+        console.error("expected:", testCase.expected.title);
+        console.error("result:", result.title);
+        console.error();
+        break;
+      }
+
+      if (result.body !== testCase.expected.body) {
+        console.error("FAILED: body");
+        console.error("expected:", testCase.expected.body);
+        console.error("result:", result.body);
+        console.error();
+        break;
+      }
+
+      // expect(result.frontMatter).to.deep.equal(testCase.expected.frontMatter);
+
+      if (
+        JSON.stringify(result.frontMatter) !==
+        JSON.stringify(testCase.expected.frontMatter)
+      ) {
+        console.error("FAILED: front matter");
+        console.error(diff(result.frontMatter, testCase.expected.frontMatter));
+        console.error("expected:", testCase.expected.frontMatter);
+        console.error("result:", result.frontMatter);
+        // console.error(
+        //   "expected:",
+        //   JSON.stringify(testCase.expected.frontMatter),
+        // );
+        // console.error("result:", JSON.stringify(result.frontMatter));
+        // console.error();
+        break;
+      }
+
+      console.info("SUCCESS:", result);
+      console.info();
+      console.info();
+    }
+  }
+}
+
+interface ParseTitleAndFrontMatterRes {
+  title: string;
+  frontMatter: Record<string, any>;
+  body: string;
+}
+
+function parseTitleAndFrontMatter(contents: string) {
+  const lines = contents.split("\n");
+
+  let title = "";
+  let frontMatter: Record<string, any> = {};
+  let bodyStartIndex = 0;
+
+  // Process the title (assuming it's the first line starting with '#')
+  if (lines[0].startsWith("#")) {
+    title = lines[0].replace(/^#\s*/, "").trim();
+    bodyStartIndex = 1; // Move index to the next line
+  }
+
+  // Check for front matter by looking line by line until an empty line
+  let frontMatterLines = [];
+
+  // Notion style front matter has no --- border, just new lines; but support
+  // --- style too b/c that is what I used in other notes.... this is maybe stupid
+  // supporting bothin the same importer. Likely refactor when this is properly abstracted
+  // :hopesanddreams:
+  let fontMatterBorderTriggered = false;
+
+  // Notion style document is:
+  // title, newline, frontmatter(optional), newline(if front matter), body
+  let firstSpaceEncountered = false;
+  for (let i = bodyStartIndex; i < lines.length; i++) {
+    const line = lines[i].trim();
+
+    // Track the start of frontmatter if using ---, so we can later
+    // detect --- and infer the end of front matter (as opposed to an empty line)
+    if (i == bodyStartIndex && line == "---") {
+      fontMatterBorderTriggered = true;
+      continue;
+    }
+
+    // Stop if we reach an empty line (indicating end of front matter)
+    if (
+      i > bodyStartIndex &&
+      fontMatterBorderTriggered &&
+      line.startsWith("---")
+    ) {
+      bodyStartIndex = i + 1; // Move index to start of body content
+      break;
+    }
+
+    // Stop if we reach an empty line (indicating end of front matter)
+    if (line === "" && !fontMatterBorderTriggered) {
+      if (firstSpaceEncountered) {
+        bodyStartIndex = i + 1; // Move index to start of body content
+        break;
+      } else {
+        firstSpaceEncountered = true;
+        continue;
+      }
+    }
+
+    // Add potential front matter lines for processing
+    frontMatterLines.push(line);
+  }
+
+  if (frontMatterLines.length) {
+    const rawFrontMatter = frontMatterLines.join("\n");
+    const processedFrontMatter = preprocessFrontMatter(rawFrontMatter);
+
+    try {
+      frontMatter = yaml.parse(processedFrontMatter);
+
+      if (frontMatter.Tags) {
+        frontMatter.tags = frontMatter.Tags;
+        delete frontMatter.Tags;
+      }
+
+      // Process tags if present
+      if (frontMatter.tags) {
+        frontMatter.tags = frontMatter.tags
+          .split(",")
+          .map((tag: string) => tag.trim())
+          .filter(Boolean);
+      }
+
+      // Idiosyncratic handling of my particular front matter keys
+      // 1. I have createdAt key, but format is August 12, 2020 8:13 PM
+      // 2. updatedAt is key "Last Edited"
+      frontMatter.updatedAt = frontMatter["Last Edited"];
+      if (frontMatter.updatedAt) {
+        const date = new Date(frontMatter.updatedAt);
+        frontMatter.updatedAt = date.toISOString();
+        delete frontMatter["Last Edited"];
+      }
+
+      if (frontMatter.createdAt) {
+        const date = new Date(frontMatter.createdAt);
+        frontMatter.createdAt = date.toISOString();
+      }
+    } catch (e) {
+      console.error("Error parsing front matter", e);
+      console.log("Front matter:", rawFrontMatter);
+      throw e;
+    }
+  }
+
+  // The remaining lines form the body
+  const body = lines.slice(bodyStartIndex).join("\n").trim();
+
+  return { title, frontMatter, body };
+}
+
+// Reused preprocessFrontMatter for cleaning up front matter before parsing
+function preprocessFrontMatter(content: string) {
+  return (
+    content
+      // Handle keys with no values by assigning empty strings
+      .replace(/^(\w+):\s*$/gm, '$1: ""')
+
+      // Check if value contains special characters and quote them if necessary
+      .replace(/^(\w+):\s*(.+)$/gm, (match, key, value) => {
+        // If the value contains special characters or a newline, quote the value
+        if (value.match(/[:{}[\],&*#?|\-<>=!%@`]/) || value.includes("\n")) {
+          // If the value isn't already quoted, add double quotes
+          if (!/^['"].*['"]$/.test(value)) {
+            // Escape any existing double quotes in the value
+            value = value.replace(/"/g, '\\"');
+            return `${key}: "${value}"`;
+          }
+        }
+        return match; // Return unchanged if no special characters
+      })
+  );
+}
+
+// naive regex for matching uuidv7, for checking filenames match the format
+const uuidv7Regex =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+const SKIPPABLE_FILES = new Set(".DS_Store");
+
+// UUID in Notion notes look like 32 character hex strings; make this somewhat more lenient
+const hexIdRegex = /\b[0-9a-f]{16,}\b/;
+
+/**
+ * Strip the id from Notion filenames
+ *
+ * Notion filenames are formatted as `title UUID`
+ * example: architecture f35b7cabdf98421d94a27722f0fbdeb8
+ * @param filename - The filename (not path, no extension) to strip the UUID from
+ *
+ * @returns
+ */
+function stripNotionIdFromTitle(filename: string) {
+  const lastSpaceIndex = filename.lastIndexOf(" ");
+
+  // Only strip if a space and UUID are present after the space
+  if (
+    lastSpaceIndex > 0 &&
+    hexIdRegex.test(filename.slice(lastSpaceIndex + 1))
+  ) {
+    return filename.substring(0, lastSpaceIndex).trim();
+  }
+
+  return filename.trim();
+}
+
+export class ImporterClient {
+  constructor(
+    private db: Database,
+    private knex: Knex,
+    private journals: IJournalsClient,
+    private documents: IDocumentsClient,
+    private files: IFilesClient,
+    private preferences: IPreferencesClient,
+    private syncs: ISyncClient, // sync is keyword?
+  ) {}
+
+  private selectImages = (mdast: any, images: any = new Set()) => {
+    if (mdast.type === "image") {
+      images.add(mdast.url);
+    }
+
+    if (mdast.children) {
+      for (const child of mdast.children) {
+        this.selectImages(child, images);
+      }
+    }
+
+    return images;
+  };
+
+  /**
+   * Sync the notes directory with the database
+   */
+  import = async (importDir: string) => {
+    const rootDir = await this.preferences.get("NOTES_DIR");
+
+    if (!rootDir || typeof rootDir !== "string") {
+      throw new Error("No chronicles root directory set");
+    }
+
+    await this.files.ensureDir(importDir);
+
+    // Ensure `importDir` can be accessed, and is not a subdirectory of `rootDir`
+    if (importDir.startsWith(rootDir)) {
+      throw new Error(
+        "Import directory must not reside within the chronicles root directory",
+      );
+    }
+
+    console.log("importing directory", importDir);
+    const rootFolderName = path.basename(importDir);
+
+    // Track created journals and number of documents to help troubleshoot
+    // sync issues
+    const journals: Record<string, number> = {};
+    const erroredDocumentPaths: string[] = [];
+
+    for await (const file of Files.walk(importDir, () => true, {
+      // depth: dont go into subdirectories
+      depthLimit: 1,
+    })) {
+      // For some reason it yields the root folder first, what is the point of that shrug
+      if (file.path == rootFolderName) continue;
+      const { ext, name, dir } = path.parse(file.path);
+
+      // Skip hidden files and directories
+      if (name.startsWith(".")) continue;
+      if (SKIPPABLE_FILES.has(name)) continue;
+
+      if (file.stats.isDirectory()) {
+        const directory = name;
+        if (directory === "_attachments") {
+          continue;
+        }
+
+        // Defer creating journals until we find a markdown file
+        // in the directory
+        continue;
+      }
+
+      // Only process markdown files
+      if (ext !== ".md") continue;
+
+      // filename is id; ensure it is formatted as a uuidv7
+      // compared to sync, we do not assume the filename is a uuidv7
+      // const documentId = path.basename(file.path).replace(".md", "");
+
+      // if (!uuidv7Regex.test(documentId)) {
+      //   console.error("Invalid document id", documentId);
+      //   continue;
+      // }
+
+      // treated as journal name
+      // NOTE: This directory check only works because we limit depth to 1
+      const dirname = path.basename(dir);
+      const journalName = stripNotionIdFromTitle(dirname);
+
+      // Once we find at least one markdown file, we treat this directory
+      // as a journal
+      if (!(journalName in journals)) {
+        await this.files.ensureDir(dirname);
+
+        // current work: Separate create from index; instead just re-work notion folder structure into
+        // chronicles structure as we import, then call sync;
+        // So, I don't think we need to even create journals, I think the folder is created when the first file is
+        // created .... remove this later.
+        // await this.journals.index(dirname);
+        journals[journalName] = 0;
+      }
+
+      // this is only special for sync, not import
+      // _attachments is for images (etc), not notes
+      // TODO: Allow dir named _attachments; but would need to re-name it on import
+      // if (directory == "_attachments") {
+      //   continue;
+      // }
+
+      // todo: handle repeat import, specifically if the imported folder / file already exists;
+      // b/c that may happen when importing multiple sources...
+
+      // todo: sha comparison
+      const contents = await Files.read(file.path);
+      try {
+        const { frontMatter, body, title } = parseTitleAndFrontMatter(contents);
+        console.log("parsed", JSON.stringify(frontMatter, null, 2));
+
+        // In a directory that was pre-formatted by Chronicles, this should not
+        // be needed. Will leave here as a reminder when I do the more generalized
+        // import routine.
+        if (!frontMatter.createdAt) {
+          frontMatter.createdAt = file.stats.ctime.toISOString();
+        }
+
+        // todo: check updatedAt Updated At, Last Edited, etc.
+        // createdAt
+        if (!frontMatter.updatedAt) {
+          frontMatter.updatedAt = file.stats.mtime.toISOString();
+        }
+
+        // todo: handle additional kinds of frontMatter; just add a column for them
+        // and ensure they are not overwritten when editing existing files
+        // https://github.com/cloverich/chronicles/issues/127
+
+        // todo: Unlike sync, here we need to handle images and note references
+        // there are two kinds of note references: file references, and [[Magic References]]
+
+        try {
+          // sync calls createIndex, but we call createDocument
+          // NOTE: This is not idempotent; we could make it so by tracking
+          // the original file path
+          await this.documents.createDocument(
+            {
+              journal: journalName, // using name as id
+              content: body,
+              title: title, //stripNotionIdFromTitle(name),
+              tags: frontMatter.tags || [],
+              createdAt: frontMatter.createdAt,
+              updatedAt: frontMatter.updatedAt,
+            },
+            false, // don't index; we'll call sync after import
+          );
+        } catch (e) {
+          erroredDocumentPaths.push(file.path);
+
+          // https://github.com/cloverich/chronicles/issues/248
+          console.error(
+            "Error creating document",
+            file.path,
+            "for journal",
+            dirname,
+            e,
+          );
+        }
+      } catch (e) {
+        console.error("Error parsing front matter", file.path, e);
+        // console.log(contents);
+        continue;
+      }
+    }
+
+    console.log("import complete; calling sync to update indexes");
+    await this.syncs.sync();
+  };
+}

--- a/src/preload/client/preferences.ts
+++ b/src/preload/client/preferences.ts
@@ -57,17 +57,33 @@ export class PreferencesClient {
   //   ipcRenderer.send("select-user-files-dir");
   // };
 
+  openDialogImportDir = async () => {
+    ipcRenderer.send("select-directory");
+
+    return new Promise<string>((resolve, reject) => {
+      ipcRenderer.once("directory-selected", (event, arg) => {
+        console.log("directory-selected", arg);
+        if (arg.error) {
+          reject(arg.error);
+        } else {
+          resolve(arg.value);
+        }
+      });
+    });
+  };
+
   openDialogNotesDir = async () => {
-    ipcRenderer.send("select-chronicles-root");
+    ipcRenderer.send("select-directory");
 
     return new Promise<{ error?: string; value?: string }>(
       (resolve, reject) => {
-        ipcRenderer.once("preferences-updated", (event, arg) => {
-          console.log("preferences-updated", arg);
+        ipcRenderer.once("directory-selected", (event, arg) => {
+          console.log("directory-selected", arg);
           if (arg.error) {
             reject(arg.error);
           } else {
-            resolve(arg);
+            this.set("NOTES_DIR", arg.value);
+            resolve(arg.value);
           }
         });
       },

--- a/src/preload/client/types.ts
+++ b/src/preload/client/types.ts
@@ -1,5 +1,6 @@
 import { IDocumentsClient } from "./documents";
 import { IFilesClient } from "./files";
+import { IImporterClient } from "./importer";
 import { IJournalsClient } from "./journals";
 import { IPreferencesClient } from "./preferences";
 import { ISyncClient } from "./sync";
@@ -15,7 +16,8 @@ export interface IClient {
   documents: IDocumentsClient;
   preferences: IPreferencesClient;
   files: IFilesClient;
-  imports: ISyncClient;
+  sync: ISyncClient;
+  importer: IImporterClient;
 }
 
 export type JournalResponse = {

--- a/src/views/preferences/index.tsx
+++ b/src/views/preferences/index.tsx
@@ -31,7 +31,7 @@ const Preferences = observer(() => {
     store.loading = true;
     try {
       const result = await client.preferences.openDialogNotesDir();
-      if (!result.value) {
+      if (!result) {
         store.loading = false;
         return;
       }
@@ -45,12 +45,30 @@ const Preferences = observer(() => {
     }
   }
 
+  async function openDialogImportDir() {
+    store.loading = true;
+    try {
+      const result = await client.preferences.openDialogImportDir();
+      if (!result) {
+        store.loading = false;
+        return;
+      }
+
+      await client.importer.import(result);
+      store.loading = false;
+    } catch (e) {
+      console.error("Error importing directory", e);
+      store.loading = false;
+      toaster.danger("Failed to import directory");
+    }
+  }
+
   async function sync() {
     if (store.loading) return;
 
     toaster.notify("Syncing cache...may take a few minutes");
     store.loading = true;
-    await client.imports.sync();
+    await client.sync.sync();
     await jstore.refresh();
     store.loading = false;
     toaster.success("Cache synced");
@@ -128,6 +146,19 @@ const Preferences = observer(() => {
             onClick={openDialogNotesDir}
           >
             Select new directory
+          </Button>
+        </SettingsBox>
+        <SettingsBox>
+          <h4>Import markdown directory</h4>
+          <p>Import a directory of markdown files. Experimental.</p>
+
+          {/* todo: https://stackoverflow.com/questions/8579055/how-do-i-move-files-in-node-js/29105404#29105404 */}
+          <Button
+            isLoading={store.loading}
+            disabled={store.loading}
+            onClick={openDialogImportDir}
+          >
+            Select directory
           </Button>
         </SettingsBox>
         <SettingsBox>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
 
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
-    "target": "es2018" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
+    "target": "es2020" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
     "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -2636,6 +2636,11 @@ deep-extend@^0.6.0:
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
   integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
+deep-object-diff@^1.1.9:
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/deep-object-diff/-/deep-object-diff-1.1.9.tgz#6df7ef035ad6a0caa44479c536ed7b02570f4595"
+  integrity sha512-Rn+RuwkmkDwCi2/oXOFS9Gsr5lJZu/yTGpK7wAaAIE75CC+LCGEZHpY6VQJa/RoJcrmaA/docWJZvYohlNkWPA==
+
 defaults@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/defaults/-/defaults-1.0.3.tgz#c656051e9817d9ff08ed881477f3fe4019f3ef7d"


### PR DESCRIPTION
Currently heavily WIP in support of #132 / #134 - not making this super generic, just supporting _my_ notion export and leaving placeholders (like #256 ) for future work. As of initial commit it imports my notion export and makes journals / titles correctly, but does not re-write note links or import image/file references.

Changes:

- add importer for my notion export
- re-name prior importer client to sync client
- add diff dependency for temporary hacky testing helper
- allow creating documents without indexing, to support import-then-sync approach
- types to es2020 for a misc lib function I needed

Todo:
- [x] Add Notion import in preferences
- [x] Re-work to import-then-sync approach
- [x] Re-name journals and notes (remove notion id)
- [x] Parse front matter if present
- [x] Maintain created / updated at based on front matter or ctime / mtime
- [x] Import tags (if in front matter as `Tags`)
- [ ] Import basic note links
- [ ] Import images / files and update references
- [ ] Track or log failed import items / references


Out of scope:
- Multi-line front matter (#256)
- Arbitrary front matter (hard-coded to ones I have and need; may do this though rather than discarding outright hmm)