### PR TITLE
refactor uuidv7 to compact version

### DIFF
--- a/src/preload/client/documents.ts
+++ b/src/preload/client/documents.ts
@@ -1,6 +1,6 @@
 import { Database } from "better-sqlite3";
 import { Knex } from "knex";
-import { uuidv7 } from "uuidv7";
+import { uuidv7obj } from "uuidv7";
 import { IFilesClient } from "./files";
 
 export interface GetDocumentResponse {
@@ -233,7 +233,7 @@ updatedAt: ${document.updatedAt}
     args: SaveRequest,
     index: boolean = true,
   ): Promise<[string, string]> => {
-    const id = args.id || uuidv7();
+    const id = args.id || uuidv7obj().toHex();
     const content = this.contentsWithFrontMatter(args);
     const docPath = await this.files.uploadDocument(
       { id, content },

--- a/src/preload/client/files.ts
+++ b/src/preload/client/files.ts
@@ -2,7 +2,7 @@ import Store from "electron-store";
 
 import fs from "fs";
 import path from "path";
-import { uuidv7 } from "uuidv7";
+import { uuidv7obj } from "uuidv7";
 const { readFile, writeFile, access, stat } = fs.promises;
 
 interface UploadResponse {
@@ -68,7 +68,7 @@ export class FilesClient {
     const dir = path.join(chronRoot, "_attachments");
 
     const { buffer, extension } = dataURLToBufferAndExtension(dataUrl);
-    const filename = `${uuidv7()}${extension}`;
+    const filename = `${uuidv7obj().toHex()}${extension}`;
     const filepath = path.join(dir, filename);
 
     return new Promise<UploadResponse>((resolve, reject) => {
@@ -91,7 +91,7 @@ export class FilesClient {
     const dir = path.join(chronRoot, "_attachments");
 
     const ext = path.parse(file.name).ext;
-    const filename = `${uuidv7()}${ext || ".unknown"}`;
+    const filename = `${uuidv7obj().toHex()}${ext || ".unknown"}`;
     const filepath = path.join(dir as string, filename);
     return new Promise<UploadResponse>((res, rej) => {
       const stream = fs.createWriteStream(filepath);

--- a/src/preload/client/importer.ts
+++ b/src/preload/client/importer.ts
@@ -18,13 +18,9 @@ import * as mdast from "../../markdown/remark-slate-transformer/models/mdast";
 
 export type IImporterClient = ImporterClient;
 
-import { uuidv7 } from "uuidv7";
+import { uuidv7obj } from "uuidv7";
 import { mdastToString, stringToMdast } from "../../markdown";
 import { parseTitleAndFrontMatter } from "./importer/frontmatter";
-
-// naive regex for matching uuidv7, for checking filenames match the format
-const uuidv7Regex =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 const SKIPPABLE_FILES = new Set(".DS_Store");
 
@@ -104,7 +100,7 @@ export class ImporterClient {
    */
   import = async (importDir: string) => {
     await this.clearImportTables();
-    const importerId = uuidv7();
+    const importerId = uuidv7obj().toHex();
     const chroniclesRoot = await this.ensureRoot();
 
     // Ensure `importDir` is a directory and can be accessed
@@ -210,7 +206,7 @@ export class ImporterClient {
 
       await this.stageNoteFiles(importerId, importDir, file.path, mdast);
 
-      const chroniclesId = uuidv7();
+      const chroniclesId = uuidv7obj().toHex();
       const importItem = {
         importerId,
         chroniclesId: chroniclesId,
@@ -491,7 +487,7 @@ export class ImporterClient {
     } catch (err) {
       // Generate a new, ugly name; user can decide what they want to do via
       // re-naming later b/c rn its not worth the complexity of doing anything else
-      journalName = uuidv7();
+      journalName = uuidv7obj().toHex();
 
       // too long, reserved name, non-unique, etc.
       // known cases from my own import:
@@ -595,7 +591,7 @@ export class ImporterClient {
       await this.knex("import_files").insert({
         importerId: importerId,
         sourcePathResolved: resolvedUrl,
-        chroniclesId: uuidv7(),
+        chroniclesId: uuidv7obj().toHex(),
         extension: path.extname(resolvedUrl),
       });
     } catch (err: any) {

--- a/src/preload/client/sync.ts
+++ b/src/preload/client/sync.ts
@@ -1,6 +1,7 @@
 import { Database } from "better-sqlite3";
 import { Knex } from "knex";
 import path from "path";
+import { UUID } from "uuidv7";
 import yaml from "yaml";
 import { Files } from "../files";
 import { GetDocumentResponse, IDocumentsClient } from "./documents";
@@ -27,10 +28,6 @@ function preprocessFrontMatter(content: string) {
       return match; // Return unchanged if no special characters
     });
 }
-
-// naive regex for matching uuidv7, for checking filenames match the format
-const uuidv7Regex =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 // naive frontmatter parser
 function parseFrontMatter(content: string) {
@@ -156,8 +153,10 @@ updatedAt: ${document.updatedAt}
       // filename is id; ensure it is formatted as a uuidv7
       const documentId = name;
 
-      if (!uuidv7Regex.test(documentId)) {
-        console.error("Invalid document id", documentId);
+      try {
+        UUID.parse(documentId);
+      } catch (e) {
+        console.error("Invalid document id", documentId, e);
         continue;
       }
 


### PR DESCRIPTION
after a bit of research, sticking with uuidv7 for the note filenames and merely dropping the hyphens; the uuidv7 package provides this via uuidv7obj().toHex(). Conveniently, their parsing function (UUID.parse) handle hyphenated and non-hyphenated versions equally well

closes #248


## migrating existing note repositories
How to migrate existing notes? After thinking on it I realized the process will be effectively free:

- All new ids (notes and files) use non-hyphenated id (this PR)
- Implement #132 
- Create a new Chronicles root, then import the old one (since its also a folder of plain markdown files)

Voila, I think it will Just Work? I guess will find out, too tired to think per usual. Amazing anything gets done on this project at all.