### PR TITLE
add source type to importer; optional notion id

### DIFF
--- a/src/electron/migrations/20211005142122.sql
+++ b/src/electron/migrations/20211005142122.sql
@@ -71,6 +71,7 @@ CREATE TABLE IF NOT EXISTS "import_notes" (
     "status" TEXT NOT NULL, -- success, error
     "chroniclesId" TEXT NOT NULL,
     "chroniclesPath" TEXT NOT NULL,
+    -- todo: sourcePath + hash of content
     "sourcePath" TEXT NOT NULL PRIMARY KEY,
     "sourceId" TEXT,
     "error" BOOLEAN,


### PR DESCRIPTION
This branch adds experimental support for non-Notion markdown import (e.g. Obsidian import). Goal is to allow me to import all my old markdown notes from two directories (one is a Notion, other is Apple Notes -> Obsidian) in a basic (experimental) sense. #258 and #271 were relevant pre-cursors to this branch. See #247 for motivation. 

- [ ] add option to importer UI for Notion / Other
- [x] add sourceType to importer
- [x] conditionally strip and track notion Id from note title
- [ ] pull title from filename
- [ ] conditionally skip (notion style) front matter
- [ ] track note creation time via ctime
- [ ] convert note and file links from Obsidian style wikilinks