### PR TITLE
update note links when journal changes

### DIFF
--- a/src/electron/migrations/20211005142122.sql
+++ b/src/electron/migrations/20211005142122.sql
@@ -38,7 +38,18 @@ CREATE TABLE IF NOT EXISTS "document_tags" (
     PRIMARY KEY ("documentId", "tag")
 );
 
+CREATE TABLE IF NOT EXISTS "document_links" (
+    "documentId" TEXT NOT NULL,
+    -- tagetId is not a foreign key, because if we delete the document, we leave
+    -- orphaned links in the original (would be weird to remove markdown links in the dependent notes)
+    "targetId" TEXT NOT NULL,
+    "targetJournal" TEXT NOT NULL,
+    "resolvedAt" TEXT,
+    FOREIGN KEY ("documentId") REFERENCES "documents" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    PRIMARY KEY ("documentId", "targetId")
+);
 
+CREATE INDEX IF NOT EXISTS "document_links_target_idx" ON "document_links"("targetId");
 CREATE INDEX IF NOT EXISTS "documents_title_idx" ON "documents"("title");
 CREATE INDEX IF NOT EXISTS "documents_createdat_idx" ON "documents"("createdAt");
 CREATE INDEX IF NOT EXISTS "tags_name_idx" ON "document_tags"("tag");

--- a/src/preload/client/files.ts
+++ b/src/preload/client/files.ts
@@ -172,7 +172,17 @@ export class FilesClient {
     const baseDir = this.settings.get("NOTES_DIR") as string;
     const newPath = path.join(baseDir, name);
 
-    return fs.promises.mkdir(newPath);
+    try {
+      await fs.promises.mkdir(newPath, { recursive: true });
+    } catch (err) {
+      // If it already exists, good to go
+      // note: ts can't find this type: instanceof ErrnoException
+      if ((err as any).code === "EEXIST") {
+        return newPath;
+      } else {
+        throw err;
+      }
+    }
   };
 
   removeFolder = async (name: string) => {

--- a/src/preload/client/importer.ts
+++ b/src/preload/client/importer.ts
@@ -18,6 +18,7 @@ export type IImporterClient = ImporterClient;
 
 import { uuidv7obj } from "uuidv7";
 import {
+  isNoteLink,
   mdastToString,
   parseMarkdownForImport as stringToMdast,
 } from "../../markdown";
@@ -419,17 +420,6 @@ export class ImporterClient {
     return linkMapping;
   };
 
-  // check if a markdown link is a link to a (markdown) note
-  private isNoteLink = (url: string) => {
-    // we are only interested in markdown links
-    if (!url.endsWith(".md")) return false;
-
-    // ensure its not a url with an .md domain
-    if (url.includes("://")) return false;
-
-    return true;
-  };
-
   private updateNoteLinks = async (
     mdast: mdast.Root | mdast.Content,
     item: StagedNote,
@@ -440,8 +430,8 @@ export class ImporterClient {
   ) => {
     // todo: update ofmWikilink
     // todo: update links that point to local files
-    if (mdast.type === "link" && this.isNoteLink(mdast.url)) {
-      const url = decodeURIComponent(mdast.url);
+    if (isNoteLink(mdast as mdast.RootContent)) {
+      const url = decodeURIComponent((mdast as mdast.Link).url);
       const sourceFolderPath = path.dirname(item.sourcePath);
       const sourceUrlResolved = path.resolve(sourceFolderPath, url);
       const mapped = linkMapping[sourceUrlResolved];

--- a/src/preload/client/importer/FilesImportResolver.ts
+++ b/src/preload/client/importer/FilesImportResolver.ts
@@ -3,6 +3,7 @@ import { Knex } from "knex";
 import mdast from "mdast";
 import path from "path";
 import { uuidv7obj } from "uuidv7";
+import { isNoteLink } from "../../../markdown";
 import { PathStatsFile } from "../../files";
 import { IFilesClient } from "../files";
 
@@ -135,25 +136,13 @@ export class FilesImportResolver {
     }
   };
 
-  // todo: Move this back out to importer, just copy pasted to get things working
-  // check if a markdown link is a link to a (markdown) note
-  private isNoteLink = (url: string) => {
-    // we are only interested in markdown links
-    if (!url.endsWith(".md")) return false;
-
-    // ensure its not a url with an .md domain
-    if (url.includes("://")) return false;
-
-    return true;
-  };
-
   // Determine if an mdast node is a file link
   isFileLink = (
     mdast: mdast.Content | mdast.Root,
   ): mdast is mdast.Image | mdast.Link | mdast.OfmWikiEmbedding => {
     return (
       (((mdast.type === "image" || mdast.type === "link") &&
-        !this.isNoteLink(mdast.url)) ||
+        !isNoteLink(mdast)) ||
         mdast.type === "ofmWikiembedding") &&
       !/^(https?|mailto|#|\/|\.|tel|sms|geo|data):/.test(mdast.url)
     );

--- a/src/preload/client/sync.ts
+++ b/src/preload/client/sync.ts
@@ -107,6 +107,8 @@ updatedAt: ${document.updatedAt}
     this.db.exec("delete from document_tags");
     this.db.exec("delete from documents");
     this.db.exec("delete from journals");
+    // should be automatic, from documents delete cascade
+    this.db.exec("delete from document_links");
 
     const rootDir = await this.preferences.get("NOTES_DIR");
 

--- a/src/views/edit/editor/features/note-linking/toMdast.ts
+++ b/src/views/edit/editor/features/note-linking/toMdast.ts
@@ -35,10 +35,11 @@ const noteLinkRegex = /^\..\/(?:(.+)\/)?([a-zA-Z0-9-]+)\.md$/;
 /**
  * Check if url conforms to the note link format.
  *
- * ex: `../journal/note_id.md`
+ * todo: fuse with isNoteLink in markdown/index.ts
  *
+ * ex: `../journal/note_id.md`
  */
-export function checkNoteLink(url: string) {
+export function parseNoteLink(url: string) {
   if (!url) return null;
 
   const match = url.match(noteLinkRegex);
@@ -64,7 +65,7 @@ export function toSlateNoteLink({
   deco,
   children,
 }: ToSlateLink) {
-  const res = checkNoteLink(url);
+  const res = parseNoteLink(url);
 
   if (res) {
     return {


### PR DESCRIPTION
- when changing journal of note A, find all notes that point to it and update their links

A few notes. Because we store links like:

```
[My title](../journal_a/abc123.md)
```

If the abc123 note changes its journal from journal_a to journal_b, we need to go find all notes that reference it, and update their markdown link, e.g. to `(../journal_b/abc123.md)`. To support this I introduce a links table here. In general straight forward but:

- Its first time modifying one note affects others, and adds new complexity
- Because Chronicles loads notes by id only, and ids are unique, we don't actually use the journal name when resolving; if we fail to update the links, they will all still work (in Chronicles)
- `[[WikiLink]]` skirt this problem by not encoding valid markdown links to begin with; given Chronicles already resolves by id its nearly there. Using Wikilinks by default would let us kick out this complexity, at the expense of the underlying markdown not being fully valid. Its what Obsidian does, and probably fine. 
- We don't do anything on delete. The links table is updated via cascade, and dependent note links naturally stop working (just as they would if user deleted on disk). 


Overall at this point I lean towards moving Chronicles to Wikilinks, and then we don't even need the links table b/c we can resolve id-based links by searching the documents table. For now this works; but may re-visit soon. 

Closes #251 