### PR TITLE
maintain import tables; document clearing; fix import bugs

### DIFF
--- a/src/electron/migrations/20211005142122.sql
+++ b/src/electron/migrations/20211005142122.sql
@@ -97,7 +97,6 @@ CREATE TABLE IF NOT EXISTS "import_notes" (
     "sourcePath" TEXT NOT NULL PRIMARY KEY,
     "sourceId" TEXT,
     "error" BOOLEAN,
-    "title" TEXT NOT NULL,
     "journal" TEXT NOT NULL,
     "frontMatter" TEXT,
     "content" TEXT

--- a/src/markdown/index.test.ts
+++ b/src/markdown/index.test.ts
@@ -5,7 +5,12 @@ import path from "path";
 import yaml from "yaml";
 
 import { slateToString, stringToSlate } from "./index.js";
-import { dig, parseMarkdown, parseMarkdownForImport } from "./test-utils.js";
+import {
+  dedent,
+  dig,
+  parseMarkdown,
+  parseMarkdownForImport,
+} from "./test-utils.js";
 
 // Tests can structure the data this way and use runTests to
 // test the various conversions.
@@ -619,26 +624,26 @@ describe("Whacky shit", function () {
 });
 
 describe("front matter parsing", function () {
-  const content = `---
-title: 2024-09-29
-tags: weekly-todo
-createdAt: 2024-09-30T17:50:22.000Z
-updatedAt: 2024-11-04T16:24:11.000Z
----
-
-#weekly-todo
-
-Last week: [2024-09-22](../work/0193acd4fa3574698c36c4514b907c70.md)
-
-**I am on call this week** [On call week of 2024-09-30](../persona/0193acd4fa45731f81350d4443c1ed16.md)
-
-## Monday
-  
-`;
-
   // A very basic "it works" test
   // todo: End to end test with a real document, asserting against the database values
   it("parses front matter as an mdast node, and can be parsed with yaml.parse", function () {
+    const content = dedent(`---
+    title: 2024-09-29
+    tags: weekly-todo
+    createdAt: 2024-09-30T17:50:22.000Z
+    updatedAt: 2024-11-04T16:24:11.000Z
+    ---
+    
+    #weekly-todo
+    
+    Last week: [2024-09-22](../work/0193acd4fa3574698c36c4514b907c70.md)
+    
+    **I am on call this week** [On call week of 2024-09-30](../persona/0193acd4fa45731f81350d4443c1ed16.md)
+    
+    ## Monday
+    
+    `);
+
     const parsed = parseMarkdown(content);
     expect(parsed.children[0].type).to.equal("yaml");
     expect(parsed.children[0].value).to.equal(
@@ -654,6 +659,21 @@ Last week: [2024-09-22](../work/0193acd4fa3574698c36c4514b907c70.md)
       tags: "weekly-todo",
       createdAt: "2024-09-30T17:50:22.000Z",
       updatedAt: "2024-11-04T16:24:11.000Z",
+    });
+  });
+
+  it("handles colons in front matter titles", function () {
+    const content = dedent(`---
+    title: "2024-09-29: A day to remember"
+    ---
+    
+    Last week I...
+    `);
+
+    const parsed = parseMarkdown(content);
+    const frontMatter = yaml.parse(parsed.children[0].value as string);
+    expect(frontMatter).to.deep.equal({
+      title: "2024-09-29: A day to remember",
     });
   });
 });

--- a/src/markdown/index.ts
+++ b/src/markdown/index.ts
@@ -54,9 +54,11 @@ function wrapImages(tree: mdast.Root) {
   return tree;
 }
 
-// The importer has additional support for #tag and [[WikiLink]], but converts them
+// During import (processing) parse #tag and [[WikiLink]]; importer converts them
 // to Chronicles tags and markdown links. Future versions may support these properly.
-export const parseMarkdownForImport = (markdown: string): mdast.Root => {
+export const parseMarkdownForImportProcessing = (
+  markdown: string,
+): mdast.Root => {
   return fromMarkdown(markdown, {
     extensions: [gfm(), ofmTag(), ofmWikilink(), frontmatter(["yaml"])],
     mdastExtensions: [
@@ -64,7 +66,6 @@ export const parseMarkdownForImport = (markdown: string): mdast.Root => {
       ofmTagFromMarkdown(),
       ofmWikilinkFromMarkdown(),
       // https://github.com/micromark/micromark-extension-frontmatter?tab=readme-ov-file#preset
-      // todo: support toml (need toml parser)
       frontmatterFromMarkdown(["yaml"]),
     ],
   });

--- a/src/markdown/test-utils.ts
+++ b/src/markdown/test-utils.ts
@@ -1,7 +1,7 @@
 import { Root } from "mdast";
 
 import {
-  parseMarkdownForImport as parseMarkdownForImportRaw,
+  parseMarkdownForImportProcessing as parseMarkdownForImportRaw,
   parseMarkdown as parseMarkdownRaw,
 } from "./index.js";
 
@@ -42,4 +42,54 @@ export function dig(obj: any, path: string) {
       );
     }
   }, obj);
+}
+
+// Adapted from https://github.com/MartinKolarik/dedent-js
+// Copyright (c) 2015 Martin Kolárik. Released under the MIT license.
+export function dedent(
+  templateStrings: TemplateStringsArray | string,
+  ...values: any[]
+) {
+  let matches = [];
+  let strings =
+    typeof templateStrings === "string"
+      ? [templateStrings]
+      : templateStrings.slice();
+
+  // 1. Remove trailing whitespace.
+  strings[strings.length - 1] = strings[strings.length - 1].replace(
+    /\r?\n([\t ]*)$/,
+    "",
+  );
+
+  // 2. Find all line breaks to determine the highest common indentation level.
+  for (let i = 0; i < strings.length; i++) {
+    let match;
+
+    if ((match = strings[i].match(/\n[\t ]+/g))) {
+      matches.push(...match);
+    }
+  }
+
+  // 3. Remove the common indentation from all strings.
+  if (matches.length) {
+    let size = Math.min(...matches.map((value) => value.length - 1));
+    let pattern = new RegExp(`\n[\t ]{${size}}`, "g");
+
+    for (let i = 0; i < strings.length; i++) {
+      strings[i] = strings[i].replace(pattern, "\n");
+    }
+  }
+
+  // 4. Remove leading whitespace.
+  strings[0] = strings[0].replace(/^\r?\n/, "");
+
+  // 5. Perform interpolation.
+  let string = strings[0];
+
+  for (let i = 0; i < values.length; i++) {
+    string += values[i] + strings[i + 1];
+  }
+
+  return string;
 }

--- a/src/preload/client/importer/FilesImportResolver.ts
+++ b/src/preload/client/importer/FilesImportResolver.ts
@@ -38,7 +38,7 @@ export class FilesImportResolver {
   ): Promise<string | undefined> => {
     // check db for chronicles id matching name, if any
     const result = await this.knex("import_files")
-      .where({ filename: name })
+      .where({ filename: name, importerId: this.importerId })
       .select("chroniclesId", "extension")
       .first()!;
 

--- a/src/preload/client/index.ts
+++ b/src/preload/client/index.ts
@@ -10,7 +10,6 @@ import { TagsClient } from "./tags";
 import { IClient } from "./types";
 
 import Store from "electron-store";
-import { runTests } from "./importer/importer.test";
 const settings = new Store({
   name: "settings",
 });
@@ -40,7 +39,7 @@ let client: IClient;
 class TestsClient {
   constructor(private importer: ImporterClient) {}
   runTests = () => {
-    runTests(this.importer);
+    console.log("todo: fixme");
   };
 }
 

--- a/src/views/preferences/index.tsx
+++ b/src/views/preferences/index.tsx
@@ -70,6 +70,19 @@ const Preferences = observer(() => {
     }
   }
 
+  async function clearImportTable() {
+    store.loading = true;
+    try {
+      await client.importer.clearImportTables();
+      store.loading = false;
+      toaster.success("Import table cleared");
+    } catch (e) {
+      console.error("Error clearing import table", e);
+      store.loading = false;
+      toaster.danger("Failed to clear import table");
+    }
+  }
+
   async function sync() {
     if (store.loading) return;
 
@@ -115,10 +128,10 @@ const Preferences = observer(() => {
       <Base.TitlebarSpacer />
       <Base.ScrollContainer>
         <SettingsBox>
-          <h4>Settings directory</h4>
+          <h4>Settings</h4>
+          <p>Settings file: {client.preferences.settingsPath()}</p>
           <p>
-            Location of files / directories are persisted to the settings file
-            located at {client.preferences.settingsPath()}
+            Database file: <code>{store.preferences.DATABASE_URL}</code>
           </p>
         </SettingsBox>
         <SettingsBox>
@@ -144,21 +157,14 @@ const Preferences = observer(() => {
         <SettingsBox>
           <h4>Import markdown directory</h4>
           <p>Import a directory of markdown files. Experimental.</p>
-          <p>The following file / directory names will be skipped:</p>
-          <ul>
-            {Array.from(SKIPPABLE_FILES).map((file) => (
-              <li key={file}>{file}</li>
-            ))}
-          </ul>
+          <p>
+            The following file / directory names will be skipped:&nbsp;
+            {Array.from(SKIPPABLE_FILES).join(", ")}
+          </p>
           <p>
             Other than _attachments, the following prefixes will cause a file or
-            directory to be skipped:
+            directory to be skipped: {Array.from(SKIPPABLE_PREFIXES).join(", ")}
           </p>
-          <ul>
-            {Array.from(SKIPPABLE_PREFIXES).map((prefix) => (
-              <li key={prefix}>{prefix}</li>
-            ))}
-          </ul>
 
           <Select
             selected={store.sourceType}
@@ -174,7 +180,25 @@ const Preferences = observer(() => {
             disabled={store.loading}
             onClick={importDirectory}
           >
-            Select directory
+            Import directory
+          </Button>
+
+          <h3>Clear Import Tables</h3>
+          <p>
+            ADVANCED: Re-running import from same location will skip previously
+            imported files. To fully re-run the import, you can clear the import
+            tables by clicking below, but this will result in duplicate files
+            unless the prior imported files are removed (manually, by you) from
+            root directory. Note ids are generated and tracked in the import
+            table prior to creating the files, so these can be used to
+            (manually) link imported files to their location in Chronicles.
+          </p>
+          <Button
+            intent="danger"
+            onClick={clearImportTable}
+            disabled={store.loading}
+          >
+            Clear import table
           </Button>
         </SettingsBox>
         <SettingsBox>


### PR DESCRIPTION
  - re-work import process to maintain data in import table by default
  - fix staging error tracking so staging errors are kept but cleared on re-run
  - expose clear import tables button on settings, document it
  - fix bug where tags or wikilinks in document would cause import to fail at staging phase (+test)
  - fix bug where same filename from different import would be preferentially used
  - fix bug where empty document would fail to import (potentially leaving valid title / frontmatter behind) (+test)
  - add success message when clear import button succeeds


Import errors can now be found in the table and I used this process to fix my own notes, rather than have Chronicles attempt to repair everything on import (scope was blowing up). Exposed a button to clear import tables, to allow re-importing. 
<img width="400" alt="Screenshot 2024-12-24 at 8 01 11 AM" src="https://github.com/user-attachments/assets/d8553e34-72ed-40dd-bac0-f75065ecd6b0" />

Note a great UX, but these two paths are possible (and I used them myself):

1. Tons of errors or unexpected issues. Delete files in Chronicles, then re-run import
2. A few issues identified at staging. Fix the source documents (example: add quotes to titles with colons in them) and then re-run the import


_Staging_ errors are cleared automatically on each import run; everything else is persisted so re-running the importer will not create duplicate files. One major limitation is if imports are done in batches (while fixing errors), links between correct vs broken notes won't be setup properly. Chronicles could fix this, and / or could track links to surface it, but that's yet more scope. Can re-visit in future if app see's usage.

NOTE: This is the final (planned) PR in #247; at this point I can run an import from:
- My prior Chronicles directory
- My Obsidian directory
- My exported Notion directory

And all three show up in Chronicles in a functional state. There's still edge cases I don't handle (noted in code); performance of sync is bad; the IDs dont sort the way I'd hoped. But at this point the original intent of v0.8 is complete. 

Closes #276 
