### PR TITLE
clean up frontmatter tests and add importer test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,4 +27,5 @@ jobs:
         with:
           node-version: 20.x
       - run: yarn install
-      - run: yarn run test
+      - name: Run tests
+        run: yarn run test

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ yarn
 yarn start
 
 # If error with sqlite library versions
-yarn run electron-rebuild
+yarn run electron-rebuild --force
 ```
 
 See scripts/dev.js for specifics on how the source files are compiled and re-loaded in development.

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "chai": "^5.0.3",
     "class-variance-authority": "^0.7.0",
     "date-fns": "^3.3.1",
-    "deep-object-diff": "^1.1.9",
     "electron": "^28.2.0",
     "esbuild": "^0.20.0",
     "evergreen-ui": "^7.1.9",

--- a/src/markdown/index.ts
+++ b/src/markdown/index.ts
@@ -13,8 +13,11 @@ import { gfmFromMarkdown, gfmToMarkdown } from "mdast-util-gfm";
 import { toMarkdown } from "mdast-util-to-markdown";
 import { frontmatter } from "micromark-extension-frontmatter";
 import { gfm } from "micromark-extension-gfm";
-import { ofmTagFromMarkdown } from "./mdast-util-ofm-tag";
-import { ofmWikilinkFromMarkdown } from "./mdast-util-ofm-wikilink";
+import { ofmTagFromMarkdown, ofmTagToMarkdown } from "./mdast-util-ofm-tag";
+import {
+  ofmWikilinkFromMarkdown,
+  ofmWikilinkToMarkdown,
+} from "./mdast-util-ofm-wikilink";
 import { ofmTag } from "./micromark-extension-ofm-tag";
 import { ofmWikilink } from "./micromark-extension-ofm-wikilink";
 import { mdastToSlate } from "./remark-slate-transformer/transformers/mdast-to-slate.js";
@@ -68,6 +71,19 @@ export const parseMarkdownForImportProcessing = (
       // https://github.com/micromark/micromark-extension-frontmatter?tab=readme-ov-file#preset
       frontmatterFromMarkdown(["yaml"]),
     ],
+  });
+};
+
+export const serializeMarkdownForImportProcessing = (tree: mdast.Nodes) => {
+  return toMarkdown(tree, {
+    extensions: [
+      gfmToMarkdown() as any,
+      ofmTagToMarkdown(),
+      ofmWikilinkToMarkdown(),
+      frontmatterToMarkdown(["yaml"]),
+    ],
+    bullet: "-",
+    emphasis: "_",
   });
 };
 

--- a/src/preload/client/importer/frontmatter.test.ts
+++ b/src/preload/client/importer/frontmatter.test.ts
@@ -1,5 +1,3 @@
-// todo drop this diff lib if migrated to mocha
-import { diff } from "deep-object-diff";
 import { SourceType } from "./SourceType";
 import { parseTitleAndFrontMatterForImport } from "./frontmatter";
 
@@ -7,383 +5,325 @@ import { expect } from "chai";
 import { describe, it } from "mocha";
 import { dedent } from "../../../markdown/test-utils";
 
-// to the console; can convert to real tests at the end.
-// todo(chris): Finish refactoring all these tests to be run with Mocha
-// they are left over from some manual testing that required preload
-// i.e could not be run via mocha
-function runFrontmatterTests() {
-  for (const testCase of titleFrontMatterTestCases) {
-    it(testCase.input, () => {
-      expect(testCase.input).to.be.a("string");
-    });
+export const cases = {
+  [SourceType.Notion]: [
+    {
+      name: "Title and simple front matter with no special characters",
+      input: dedent(
+        `
+      # My First Note
 
-    const result = parseTitleAndFrontMatterForImport(
-      testCase.input,
-      "Dont use this title",
-      SourceType.Notion,
-    );
+      Created By: Johnny Cage
+      Last Edited: July 20, 2023 12:00 PM
+      Category: personal
+      createdAt: January 1, 2021
+      published: Yes
 
-    if (!result.frontMatter) {
-      console.error("FAILED:", testCase.expected.title);
-      console.error("FAILED No front matter parsed");
-      console.error(testCase.input);
-      break;
-    } else {
-      if (result.frontMatter.title !== testCase.expected.title) {
-        console.error("FAILED:", testCase.expected.title);
-        console.error("FAILED title");
-        console.error("We should have:", testCase.expected.title);
-        console.error("We got:", result.frontMatter.title);
-        console.error();
-        break;
-      }
-
-      if (result.body !== testCase.expected.body) {
-        console.error("FAILED:", testCase.expected.title);
-        console.error("FAILED parsing body");
-        console.error("We should have:", testCase.expected.body);
-        console.error("We got:", result.body);
-        console.error();
-        break;
-      }
-
-      // expect(result.frontMatter).to.deep.equal(testCase.expected.frontMatter);
-
-      const difference = diff(
-        result.frontMatter,
-        testCase.expected.frontMatter,
-      );
-      if (Object.keys(difference).length) {
-        console.error("FAILED:", testCase.expected.title);
-        console.error("FAILED parsing front matter");
-        console.error(difference);
-        console.error("^ was diff, was it useless? lets log json instead...");
-        console.error(
-          "Should have (string):",
-          JSON.stringify(testCase.expected.frontMatter),
-        );
-        console.error("We got (string):", JSON.stringify(result.frontMatter));
-        console.error("We should have:", testCase.expected.frontMatter);
-        console.error("We got:", result.frontMatter);
-        break;
-      }
-
-      console.info("SUCCESS: ", testCase.expected.title);
-      console.info();
-      console.info();
-    }
-  }
-}
-
-export const titleFrontMatterTestCases = [
-  // Title and simple front matter with no special characters
-  {
-    input: `# My First Note
-
-Created By: John Doe
-Last Edited: July 20, 2023 12:00 PM
-Category: personal
-createdAt: January 1, 2021
-published: Yes
-
-This is the body of the document.`,
-    expected: {
-      title: "My First Note",
-      frontMatter: {
-        "Created By": "John Doe",
-        Category: "personal",
-        createdAt: "2021-01-01T08:00:00.000Z",
-        published: "Yes",
-        updatedAt: "2023-07-20T19:00:00.000Z",
+      This is the body of the document.`.trim(),
+      ),
+      expected: {
+        title: "My First Note",
+        frontMatter: {
+          title: "My First Note",
+          tags: [],
+          "Created By": "Johnny Cage",
+          Category: "personal",
+          createdAt: "2021-01-01T00:00:00.000Z",
+          published: "Yes",
+          updatedAt: "2023-07-20T12:00:00.000Z",
+        },
+        body: "This is the body of the document.",
       },
-      body: "This is the body of the document.",
     },
-  },
+    {
+      name: "Title with no front matter",
+      input: dedent(
+        `
+      # Another Note
 
-  // Title with no front matter
-  {
-    input: `# Another Note
-
-This document has no front matter, just content.`,
-    expected: {
-      title: "Another Note",
-      frontMatter: {},
-      body: "This document has no front matter, just content.",
-    },
-  },
-
-  // Title with front matter missing values
-  {
-    input: `# Empty Values
-    
-Created By:
-Last Edited:
-tags:
-createdAt:
-published:
-
-Content for this note goes here.`,
-    expected: {
-      title: "Empty Values",
-      frontMatter: {
-        "Created By": null,
-        "Last Edited": null,
-        // Currently, empty values for these are removed to avoid confusion
-        // updatedAt: null,
-        // createdAt: null,
-        // Important: emptry tags should be an empty array, not null or "" or [""]
-        tags: [],
-        published: "",
+      This document has no front matter, just content.`.trim(),
+      ),
+      expected: {
+        frontMatter: {
+          title: "Another Note",
+          tags: [],
+        },
+        body: "This document has no front matter, just content.",
       },
-      body: "Content for this note goes here.",
     },
-  },
+    {
+      name: "Title with front matter missing values",
+      input: dedent(
+        `
+      # Empty Values
 
-  // No front-matter, colon in the body
-  {
-    input: `# Notion title + colon in body
+      Created By:
+      Last Edited:
+      tags:
+      createdAt:
+      published:
 
-Body content has a colon: in it!`,
-    expected: {
-      title: "Notion title + colon in body",
-      frontMatter: {},
-      body: "Body content has a colon: in it!",
-    },
-  },
-
-  // Frontmatter, colon in the body
-  {
-    input: `# Notion title + front matter + colon in body
-    
-Created By: John Doe
-Last Edited: July 20, 2023 12:00 PM
-Category: personal
-createdAt: January 1, 2021
-published: Yes
-
-Body content has a colon: in it!`,
-    expected: {
-      title: "Notion title + front matter + colon in body",
-      frontMatter: {
-        "Created By": "John Doe",
-        updatedAt: "2023-07-20T19:00:00.000Z",
-        Category: "personal",
-        createdAt: "2021-01-01T08:00:00.000Z",
-        published: "Yes",
+      Content for this note goes here.`.trim(),
+      ),
+      expected: {
+        frontMatter: {
+          title: "Empty Values",
+          "Created By": null,
+          "Last Edited": null,
+          tags: [],
+          published: "",
+        },
+        body: "Content for this note goes here.",
       },
-      body: "Body content has a colon: in it!",
     },
-  },
+    {
+      name: "No front matter, colon in the body",
+      input: dedent(
+        `
+      # Notion title + colon in body
 
-  // Frontmatter, no body. I have many of these in my notes.
-  {
-    input: `# Notion title + front matter + no body
-    
-Created By: John Doe
-Last Edited: July 20, 2023 12:00 PM
-Category: personal
-createdAt: January 1, 2021
-published: Yes`,
-    expected: {
-      title: "Notion title + front matter + no body",
-      frontMatter: {
-        "Created By": "John Doe",
-        updatedAt: "2023-07-20T19:00:00.000Z",
-        Category: "personal",
-        createdAt: "2021-01-01T08:00:00.000Z",
-        published: "Yes",
+      Body content has a colon: in it!`.trim(),
+      ),
+      expected: {
+        frontMatter: {
+          title: "Notion title + colon in body",
+          tags: [],
+        },
+        body: "Body content has a colon: in it!",
       },
-      body: "",
     },
-  },
-  // Notion Edge Case: No title, but front matter with special characters
-  //   {
-  //     input: `Created By: Jane Doe
-  // Last Edited: July 20, 2023 12:00 PM
-  // Category: "work, personal"
-  // createdAt: January 1, 2021 8:30 AM
-  // published: No
+    {
+      name: "Front matter, colon in the body",
+      input: dedent(
+        `
+      # Notion title + front matter + colon in body
 
-  // Body starts here and has no title.`,
-  //     expected: {
-  //       title: "",
-  //       frontMatter: {
-  //         "Created By": "Jane Doe",
-  //         "Last Edited": "July 20, 2023 12:00 PM",
-  //         Category: "work, personal",
-  //         createdAt: "January 1, 2021 8:30 AM",
-  //         published: "No",
-  //       },
-  //       body: "Body starts here and has no title.",
-  //     },
-  //   },
+      Created By: Johnny Cage
+      Last Edited: July 20, 2023 12:00 PM
+      Category: personal
+      createdAt: January 1, 2021
+      published: Yes
 
-  // Case 5: Title with multi-line front matter
-  // Nah. https://github.com/cloverich/chronicles/issues/256
-  //   {
-  //     input: `# Project Plan
-  // Created By: "Chris O"
-  // Last Edited: July 25, 2023 9:45 PM
-  // Category: project
-  // createdAt: February 15, 2021 10:30 AM
-  // description: >
-  //   This project plan outlines the goals and milestones
-  //   for the next quarter.
+      Body content has a colon: in it!`.trim(),
+      ),
+      expected: {
+        frontMatter: {
+          title: "Notion title + front matter + colon in body",
+          tags: [],
+          "Created By": "Johnny Cage",
+          updatedAt: "2023-07-20T12:00:00.000Z",
+          Category: "personal",
+          createdAt: "2021-01-01T00:00:00.000Z",
+          published: "Yes",
+        },
+        body: "Body content has a colon: in it!",
+      },
+    },
+    {
+      name: "Front matter, no body (common in Notion databases)",
+      input: dedent(
+        `
+      # Notion title + front matter + no body
 
-  // The body of the project plan begins here.`,
-  //     expected: {
-  //       title: "Project Plan",
-  //       frontMatter: {
-  //         'Created By': "Chris O",
-  //         'Last Edited': "July 25, 2023 9:45 PM",
-  //         Category: "project",
-  //         createdAt: "February 15, 2021 10:30 AM",
-  //         description:
-  //           "This project plan outlines the goals and milestones for the next quarter.",
-  //       },
-  //       body: "The body of the project plan begins here.",
-  //     },
-  //   },
+      Created By: Johnny Cage
+      Last Edited: July 20, 2023 12:00 PM
+      Category: personal
+      createdAt: January 1, 2021
+      published: Yes`.trim(),
+      ),
+      expected: {
+        frontMatter: {
+          title: "Notion title + front matter + no body",
+          tags: [],
+          "Created By": "Johnny Cage",
+          updatedAt: "2023-07-20T12:00:00.000Z",
+          Category: "personal",
+          createdAt: "2021-01-01T00:00:00.000Z",
+          published: "Yes",
+        },
+        body: "",
+      },
+    },
 
-  // Case 6: YAML-style front matter with tags; no space after last line of
-  // front matter (but has correct ---)
-  //   {
-  //     input: `---
-  // title: "YAML Note"
-  // tags: work, personal
-  // createdAt: 2023-09-28
-  // updatedAt: 2023-09-29
-  // ---
-  // This is a document with YAML front matter.`,
-  //     expected: {
-  //       title: "",
-  //       frontMatter: {
-  //         title: "YAML Note",
-  //         tags: ["work", "personal"],
-  //         createdAt: "2023-09-28",
-  //         updatedAt: "2023-09-29",
-  //       },
-  //       body: "This is a document with YAML front matter.",
-  //     },
-  //   },
+    {
+      name: "No title, front matter has special characters",
+      input: dedent(
+        `
+      Created By: Jane Doe
+      Last Edited: July 20, 2023 12:00 PM
+      Category: "work, personal"
+      createdAt: January 1, 2021 8:30 AM
+      published: No
 
-  // Case 7: YAML front matter without tags
-  //   {
-  //     input: `---
-  // title: "Note Without Tags"
-  // createdAt: 2023-09-28
-  // ---
-  // Just some plain content.`,
-  //     expected: {
-  //       title: "",
-  //       frontMatter: {
-  //         title: "Note Without Tags",
-  //         createdAt: "2023-09-28",
-  //       },
-  //       body: "Just some plain content.",
-  //     },
-  //   },
+      Body starts here and has no title.`.trim(),
+      ),
+      expected: {
+        frontMatter: {
+          title: "",
+          tags: [],
+        },
+        body: dedent(
+          `
+        Created By: Jane Doe
+        Last Edited: July 20, 2023 12:00 PM
+        Category: "work, personal"
+        createdAt: January 1, 2021 8:30 AM
+        published: No
 
-  // Case 8: No front matter or title, only body
-  // {
-  //   input: `This document only has body content.`,
-  //   expected: {
-  //     title: "",
-  //     frontMatter: {},
-  //     body: "This document only has body content.",
-  //   },
-  // },
+        Body starts here and has no title.`.trim(),
+        ),
+      },
+    },
 
-  // Case 9: Front matter with a multi-line description field
-  // https://github.com/cloverich/chronicles/issues/256
-  //   {
-  //     input: `# Notes on Testing
-  // Description: >
-  //   This document explains
-  //   the importance of testing
-  //   in software development.
+    // Nah. https://github.com/cloverich/chronicles/issues/256
+    //   {
+    //     name: "Title with multi-line front matter",
+    //     input: `# Project Plan
+    // Created By: "Chris O"
+    // Last Edited: July 25, 2023 9:45 PM
+    // Category: project
+    // createdAt: February 15, 2021 10:30 AM
+    // description: >
+    //   This project plan outlines the goals and milestones
+    //   for the next quarter.
 
-  // The body text starts here.`,
-  //     expected: {
-  //       title: "Notes on Testing",
-  //       frontMatter: {
-  //         Description:
-  //           "This document explains the importance of testing in software development.",
-  //       },
-  //       body: "The body text starts here.",
-  //     },
-  //   },
+    // The body of the project plan begins here.`,
+    //     expected: {
+    //       title: "Project Plan",
+    //       frontMatter: {
+    //         'Created By': "Chris O",
+    //         'Last Edited': "July 25, 2023 9:45 PM",
+    //         Category: "project",
+    //         createdAt: "February 15, 2021 10:30 AM",
+    //         description:
+    //           "This project plan outlines the goals and milestones for the next quarter.",
+    //       },
+    //       body: "The body of the project plan begins here.",
+    //     },
+    //   },
+  ],
+  [SourceType.Other]: [
+    {
+      name: "Title, tags (JSON aray syntax), body",
+      input: dedent(
+        `
+      ---
+      title: What chronicles was
+      tags: [tags, thesixthprototype]
+      createdAt: 2024-06-30T14:19:17.801Z
+      updatedAt: 2024-07-02T04:52:50.639Z
+      ---
+      
+      foo`.trim(),
+      ),
+      expected: {
+        frontMatter: {
+          title: "What chronicles was",
+          tags: ["tags", "thesixthprototype"],
+          createdAt: "2024-06-30T14:19:17.801Z",
+          updatedAt: "2024-07-02T04:52:50.639Z",
+        },
+        body: "foo\n",
+      },
+    },
+    {
+      name: "Title, tags (YAML aray syntax), body",
+      input: dedent(
+        `
+      ---
+      title: What chronicles was
+      tags: 
+        - mytag
+        - thesixthprototype
+      createdAt: 2024-06-30T14:19:17.801Z
+      updatedAt: 2024-07-02T04:52:50.639Z
+      ---
+      
+      foo`.trim(),
+      ),
+      expected: {
+        frontMatter: {
+          title: "What chronicles was",
+          tags: ["mytag", "thesixthprototype"],
+          createdAt: "2024-06-30T14:19:17.801Z",
+          updatedAt: "2024-07-02T04:52:50.639Z",
+        },
+        body: "foo\n",
+      },
+    },
+    {
+      name: "Title, tags, no body",
+      input: dedent(
+        `
+        ---
+        title: What chronicles was
+        tags:
+          - tags, thesixthprototype
+        createdAt: 2024-06-30T14:19:17.801Z
+        updatedAt: 2024-07-02T04:52:50.639Z
+        ---
+        `.trim(),
+      ),
+      expected: {
+        frontMatter: {
+          title: "What chronicles was",
+          // note: it doesnt fix old-style tags (comma-separated)
+          tags: ["tags, thesixthprototype"],
+          createdAt: "2024-06-30T14:19:17.801Z",
+          updatedAt: "2024-07-02T04:52:50.639Z",
+        },
+        body: "",
+      },
+    },
+    {
+      name: "tag + wikilink in body -> no error",
+      input: dedent(
+        `---
+        title: What chronicles was
+        ---
 
-  // Case 10: Mixed Notion-style front matter with YAML tags
-  //   {
-  //     input: `# Mixed Front Matter
-  // Created By: John Doe
-  // Last Edited: July 20, 2023
-  // tags: work, projects
-
-  // Body content follows after mixed front matter.`,
-  //     expected: {
-  //       title: "Mixed Front Matter",
-  //       frontMatter: {
-  //         "Created By": "John Doe",
-  //         "Last Edited": "July 20, 2023",
-  //         tags: ["work", "projects"],
-  //       },
-  //       body: "Body content follows after mixed front matter.",
-  //     },
-  //   },
-];
-
-// todo: Test with colons in the body, ensure it STOPS trying tp parse front matter
-// after the final newline; either that or pre-process the content to ...
-
-//
-export const inferOrGenerateJournalNameTestCases = [
-  // base case
-  {
-    input: "Documents c3ceaee48e24410f90a075fb72681991",
-    output: "Documents c3ceaee48e24410f90a075fb72681991",
-  },
-  // base case (nested)
-  {
-    input:
-      "Documents c3ceaee48e24410f90a075fb72681991/Attachments c3ceaee48e24410f90a075fb72681991",
-    output: "Documents_Attachments",
-  },
-  // probably works fine but shrug
-  {
-    input: "Documents",
-    output: "Documents",
-  },
-  // reserved name results in generated folder name
-  {
-    input: "_attachments",
-    // uuidv7 regex completely untested / unused just an idea
-    // because _attachments is not allowed, should be generated
-    output: /([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})/g,
-  },
-  {
-    input: "TODO_MAKE_THIS_A_TOO_LONG_INVALID_NAME_BLAHBLAHBLAH",
-    output: "TODO_...", // shorter
-  },
-];
+        This is some content with a #tag and a [[wikilink]].`.trim(),
+      ),
+      expected: {
+        frontMatter: {
+          title: "What chronicles was",
+          tags: [],
+        },
+        body: "This is some content with a #tag and a \\[\\[wikilink]].\n",
+      },
+    },
+    {
+      name: "Empty contents",
+      input: "",
+      expected: {
+        frontMatter: {
+          title: "",
+          tags: [],
+        },
+        body: "",
+      },
+    },
+  ],
+};
 
 describe("Frontmatter parsing", () => {
-  it("this does not break?", () => {
-    const parsed = parseTitleAndFrontMatterForImport(
-      dedent(
-        `---
-title: What chronicles was
-tags:
-  - tags, thesixthprototype
-createdAt: 2024-06-30T14:19:17.801Z
-updatedAt: 2024-07-02T04:52:50.639Z
----`,
-      ),
-      "",
-      SourceType.Other,
-    );
-  });
+  for (const sourceType of Object.keys(cases)) {
+    describe(sourceType, () => {
+      for (const testCase of cases[sourceType as SourceType]) {
+        it(testCase.name, () => {
+          const parsed = parseTitleAndFrontMatterForImport(
+            dedent(testCase.input),
+            "",
+            sourceType as SourceType,
+          );
+          expect(parsed.frontMatter).to.deep.equal(
+            testCase.expected.frontMatter,
+          );
+          expect(parsed.body).to.equal(testCase.expected.body);
+        });
+      }
+    });
+  }
 
   // note: Rather than trying to repair front matter issues, like colons in values (title),
   // I ended up manually fixing in my source (imported) documents; leaving this breadcrumb
@@ -402,30 +342,4 @@ updatedAt: 2024-07-02T04:52:50.639Z
   //     SourceType.Other,
   //   );
   // });
-
-  it("tags or wikilinks in content, when importing from default source", () => {
-    const parsed = parseTitleAndFrontMatterForImport(
-      dedent(`---
-        title: What chronicles was
-        ---
-
-        This is some content with a #tag and a [[wikilink]].`),
-      "",
-      SourceType.Other,
-    );
-
-    // actually testing ^ does not throw, because it re-serializes the body without
-    // the front matter, and was choking when the wrong parser was used, which parsed
-    // ofmTags but could not re-serialize them at this step.
-    expect(parsed.frontMatter.title).to.equal("What chronicles was");
-  });
-
-  it.only("empty contents -> default front matter / no error", () => {
-    const parsed = parseTitleAndFrontMatterForImport("", "", SourceType.Other);
-    expect(parsed.body).to.equal("");
-    expect(parsed.frontMatter).to.deep.equal({
-      title: "",
-      tags: [],
-    });
-  });
 });

--- a/src/preload/client/importer/frontmatter.test.ts
+++ b/src/preload/client/importer/frontmatter.test.ts
@@ -289,7 +289,7 @@ export const cases = {
           title: "What chronicles was",
           tags: [],
         },
-        body: "This is some content with a #tag and a \\[\\[wikilink]].\n",
+        body: "This is some content with a #tag and a [[wikilink]].\n",
       },
     },
     {

--- a/src/preload/client/importer/test/index.ts
+++ b/src/preload/client/importer/test/index.ts
@@ -1,0 +1,236 @@
+import { assert } from "chai";
+import { Knex } from "knex";
+import path from "path";
+import { SourceType } from "../SourceType";
+import {
+  Client,
+  GenerateFileOptions,
+  cleanup,
+  findByTitle,
+  generateFileStubs,
+  setup,
+  test,
+} from "./util";
+
+// files referenced by markdown notes in the test directory
+const binaryFileStubs: GenerateFileOptions[] = [
+  {
+    filePath:
+      "./notion/Documents c3ceaee48e24410f90a075fb72681991/The Portland Drive 6cc3eb96a4b84f0d9a80d9473379248c/Screen_Shot_2022-05-28_at_7.06.54_AM.png",
+    fileType: "png",
+  },
+  {
+    filePath:
+      "./notion/Documents c3ceaee48e24410f90a075fb72681991/The Portland Drive 6cc3eb96a4b84f0d9a80d9473379248c/Screen_Shot_2022-05-28_at_7.07.08_AM.png",
+    fileType: "png",
+  },
+  {
+    filePath:
+      "./notion/Documents c3ceaee48e24410f90a075fb72681991/The Portland Drive 6cc3eb96a4b84f0d9a80d9473379248c/IMG_1988.jpg",
+    fileType: "jpg",
+  },
+  {
+    filePath:
+      "./notion/Road Trip e3b4875d74ca4fc4a2be5d7759acc07c/Screen_Shot_2022-04-07_at_2.24.52_PM.png",
+    fileType: "png",
+  },
+  {
+    filePath:
+      "./notion/Road Trip e3b4875d74ca4fc4a2be5d7759acc07c/Screen_Shot_2022-04-07_at_3.43.30_PM.png",
+    fileType: "png",
+  },
+  {
+    filePath:
+      "./notion/Road Trip e3b4875d74ca4fc4a2be5d7759acc07c/Screen_Shot_2022-04-07_at_2.23.46_PM.png",
+    fileType: "png",
+  },
+];
+
+// rudiemntary test runner for importer tests that require a database
+// and electron environment.
+// todo: Refactor to run as a proper test suite and via CI (requires electron)
+export async function runTests() {
+  await cleanup();
+  try {
+    const { client, testdir, knex } = await setup();
+    await generateFileStubs(binaryFileStubs);
+    await testNotion(client, testdir, knex);
+  } finally {
+    await cleanup();
+  }
+}
+
+// rudiemntary tests for importing from an exported Notion directory
+async function testNotion(client: Client, testdir: string, knex: Knex) {
+  const notionImportDir = path.join(testdir, "notion");
+  await client.importer.import(
+    path.resolve(notionImportDir),
+    SourceType.Notion,
+  );
+
+  await test("imports six files", async () => {
+    const importedFiles = await knex("import_files").select("*");
+    assert.lengthOf(importedFiles, 6, "Expected to find six imported files");
+    importedFiles.forEach((file) => {
+      if (file.status !== "complete") {
+        throw new Error(
+          `File import failed with status ${file.status}: ${file.sourcePathResolved} (error, if any): ${file.error}`,
+        );
+      }
+    });
+  });
+
+  await test("imports two notes", async () => {
+    const importedNotes = await knex("import_notes").select("*");
+    assert.lengthOf(importedNotes, 2, "Expected to find two imported notes");
+    importedNotes.forEach((note) => {
+      if (note.status !== "note_created") {
+        throw new Error(
+          `Note import failed with status ${note.status}: ${note.sourcePathResolved} (error, if any): ${note.error}`,
+        );
+      }
+    });
+  });
+
+  // todo: break up better; more methodical and complete
+  await test("imported documents (notion) are linked and have expected front matter", async () => {
+    const portlandDrive = await findByTitle(client, "The Portland Drive");
+
+    // todo: control timezone in importer so here and CI can match
+    assert.equal(
+      portlandDrive.frontMatter.createdAt.slice(0, 7),
+      "2022-05",
+      'Expected document creation date to be "2022-05"',
+    );
+
+    assert.equal(
+      portlandDrive.journal,
+      "Documents",
+      'Expected "Portland Drive" document to be in journal to be "Documents"',
+    );
+
+    assert.deepInclude(portlandDrive.frontMatter, {
+      title: "The Portland Drive",
+      tags: ["review"],
+
+      // maintains original front matter
+      "Created By": "chris",
+      published: "No",
+    });
+
+    const roadTrip = await findByTitle(client, "Road Trip");
+
+    const documentLinks = await knex("document_links").where({
+      documentId: portlandDrive.id,
+      targetId: roadTrip.id,
+    });
+
+    assert.lengthOf(
+      documentLinks,
+      1,
+      'Expected "Portland Drive" to link to "Road Trip"',
+    );
+
+    // ensure document link is updated as expected
+    assert.include(
+      portlandDrive.content,
+      `[West coast road trip 2022](../notion/${roadTrip.id}.md)`,
+      'Expected Portland Drive doc to include updated link to "Road Trip"',
+    );
+  });
+
+  await test("import tables after second import", async () => {
+    const otherDir = path.join(testdir, "other");
+    await client.importer.import(path.resolve(otherDir), SourceType.Other);
+
+    // no new files
+    const importedFiles = await knex("import_files").select("*");
+    assert.lengthOf(importedFiles, 6, "Expected to find eight imported files");
+
+    // two new notes
+    const importedNotes = await knex("import_notes").select("*");
+    assert.lengthOf(importedNotes, 4, "Expected to find two imported notes");
+    importedNotes.forEach((note) => {
+      if (note.status !== "note_created") {
+        throw new Error(
+          `Note import failed with status ${note.status}: ${note.sourcePathResolved} (error, if any): ${note.error}`,
+        );
+      }
+    });
+  });
+
+  await test("imported documents (other) are linked and have expected front matter after second import", async () => {
+    const doc1 = await findByTitle(client, "Document 1");
+    const doc2 = await findByTitle(client, "Document 2");
+
+    await test("document 1 has correct structure", async () => {
+      assert.equal(
+        doc1.journal,
+        "chronicles",
+        'Expected "Document 1" to be in journal "chronicles"',
+      );
+
+      assert.deepEqual(doc1.frontMatter, {
+        title: "Document 1",
+        tags: ["devlog"],
+        createdAt: "2024-11-08T14:17:11.337Z",
+        updatedAt: "2024-11-23T19:45:56.621Z",
+      });
+    });
+
+    await test("document 2 has correct front matter", async () => {
+      assert.equal(
+        doc2.journal,
+        "chronicles",
+        'Expected "Document 2" to be in journal "chronicles"',
+      );
+
+      assert.deepEqual(doc2.frontMatter, {
+        title: "Document 2",
+        tags: ["devlog", "chronicles", "customtag"],
+        createdAt: "2024-11-09T14:46:36.190Z",
+        updatedAt: "2024-11-22T17:13:39.227Z",
+      });
+    });
+
+    await test("document links from Document 1 to Document 2", async () => {
+      const documentLinks = await knex("document_links").where({
+        documentId: doc1.id,
+        targetId: doc2.id,
+      });
+
+      assert.lengthOf(
+        documentLinks,
+        1,
+        'Expected tracked links from "Document 1" to "Document 2"',
+      );
+
+      // ensure document link is updated as expected
+      assert.include(
+        doc1.content,
+        `[Document 2](../chronicles/${doc2.id}.md)`,
+        'Expected Document 1 doc to include updated link to "Document 2"',
+      );
+    });
+
+    await test("document links from Document 2 to Document 1", async () => {
+      const documentLinks = await knex("document_links").where({
+        documentId: doc2.id,
+        targetId: doc1.id,
+      });
+
+      assert.lengthOf(
+        documentLinks,
+        1,
+        'Expected tracked links from "Document 2" to "Document 1"',
+      );
+
+      // ensure document link is updated as expected
+      assert.include(
+        doc2.content,
+        `[Document 1](../chronicles/${doc1.id}.md)`,
+        'Expected Document 2 doc to include updated link to "Document 1"',
+      );
+    });
+  });
+}

--- a/src/preload/client/importer/test/notion/Documents c3ceaee48e24410f90a075fb72681991/The Portland Drive 6cc3eb96a4b84f0d9a80d9473379248c.md
+++ b/src/preload/client/importer/test/notion/Documents c3ceaee48e24410f90a075fb72681991/The Portland Drive 6cc3eb96a4b84f0d9a80d9473379248c.md
@@ -1,0 +1,40 @@
+# The Portland Drive
+
+Created By: chris
+Last Edited: June 25, 2022 8:07 AM
+Tags: review
+createdAt: May 28, 2022 7:09 AM
+published: No
+
+The epilogue to the [West coast road trip 2022](../Road%20Trip%20e3b4875d74ca4fc4a2be5d7759acc07c.md)
+
+From Austin to Portland in ~~2487~~ 2520 miles. Two vehicles, many stops. Change of drivers and many changes of scenery. A few missed opportunities but no snags. We left the sunshine behind but brought the gratitude along with us and arrived in the overcast city we’ve talked about moving to for almost a decade. Time will tell if it was a good choice but the decision — not change for changes sake but for going after the things you want in life — I am sure we’ll be satisfied with the decision.
+
+![Screen Shot 2022-05-28 at 7.06.54 AM.png](The%20Portland%20Drive%206cc3eb96a4b84f0d9a80d9473379248c/Screen_Shot_2022-05-28_at_7.06.54_AM.png)
+
+![Screen Shot 2022-05-28 at 7.07.08 AM.png](The%20Portland%20Drive%206cc3eb96a4b84f0d9a80d9473379248c/Screen_Shot_2022-05-28_at_7.07.08_AM.png)
+
+In case I lose it, the map is [https://goo.gl/maps/rEXdwZqoHiAnt1T88.](https://goo.gl/maps/gCYcu9cuJ16NZTCX6) I’d like to stylize it, but can’t figure it out.
+
+# By the numbers
+
+We took two vehicles. One drank significantly more gas than the other. I am grateful we did not have any hiccups on the road, although with the preparation we did it wasn’t purely luck
+
+Miles: 2,520
+
+- Gas: 9 stops, $966
+  In total, our gas consumption was:
+  Total Jeep: 587.22, 8 gas stops
+  Total (VW Passat): 378.78, 7 gas stops
+  Total: 966
+  This is actually pretty close to what I predicted ($830) and less than it felt. Every time I saw that gas total approach $100 my stomach churned. But in hindsight, it didn’t add up to as much as I’d thought.
+- Hotels: $1091
+  We stopped for the night at the following places:
+  - El Paso: Casa Lopez
+  - Blythe, CA: 2 motel rooms, ??? (I guess 250, on old card)
+  - San Luis Obispo: 2 motel rooms (Peach Tree Inn), 247.74
+  - ...
+
+![We ran into Otto, an old colleague of mine, at a rest stop outside of Fredericksburg. He was the first person I remember talking to about the Portland move — 7 or 8 years ago? Wild.](The%20Portland%20Drive%206cc3eb96a4b84f0d9a80d9473379248c/IMG_1988.jpg)
+
+...

--- a/src/preload/client/importer/test/notion/Road Trip e3b4875d74ca4fc4a2be5d7759acc07c.md
+++ b/src/preload/client/importer/test/notion/Road Trip e3b4875d74ca4fc4a2be5d7759acc07c.md
@@ -1,0 +1,41 @@
+# West coast road trip 2022
+
+Notes for our 2022 road trip — where to stay, budget, etc
+
+# Time Frame
+
+Leave: Friday, May 13 2022
+
+Arrive: Friday, May 27 2022
+
+I’m aiming to have two weeks off from work. I circled Friday the 13th but in reality I’d likely leave on Saturday the 14th and take the _following_ two weeks off.
+
+![Screen Shot 2022-04-07 at 2.24.52 PM.png](Road%20Trip%20e3b4875d74ca4fc4a2be5d7759acc07c/Screen_Shot_2022-04-07_at_2.24.52_PM.png)
+
+Its about 40 hours from Austin to Portland up the coast, going through San Diego and Aptos. ~20 of those hours are the Austin → San Diego Leg that the kids won’t be on.
+
+![Screen Shot 2022-04-07 at 3.43.30 PM.png](Road%20Trip%20e3b4875d74ca4fc4a2be5d7759acc07c/Screen_Shot_2022-04-07_at_3.43.30_PM.png)
+
+# Decision Points
+
+Things we need to decide
+
+- [x] Drive with kids or fly the kids
+      We’ll fly the kids to SD with Angela, Chris and Manny will drive to SD
+- [x] Drive both cars or one car (could ship one)
+      Both
+- [x] Stay at Bernies?
+- [ ] Do we turn inland (away from Coast? When?)
+
+# Getting to the West coast (by May 16th)
+
+- Chris and Manny to drive
+- Wife and kids to fly...
+
+![Screen Shot 2022-04-07 at 2.23.46 PM.png](Road%20Trip%20e3b4875d74ca4fc4a2be5d7759acc07c/Screen_Shot_2022-04-07_at_2.23.46_PM.png)
+
+Its about 22 hours to drive. Budgeting 3 days with a stop in El Paso, we can probably do the drive in two. So if we are all there by May 16th, that leaves us a full 10+ days to make it up the coast.
+
+# Breaking up the rest of the trip
+
+...

--- a/src/preload/client/importer/test/other/chronicles/01930c22-dba9-75b6-b5e1-61a2c6c320fa.md
+++ b/src/preload/client/importer/test/other/chronicles/01930c22-dba9-75b6-b5e1-61a2c6c320fa.md
@@ -1,0 +1,8 @@
+---
+title: Document 1
+tags: devlog
+createdAt: 2024-11-08T14:17:11.337Z
+updatedAt: 2024-11-23T19:45:56.621Z
+---
+
+Wikilink to [[Document 2]] and a wikilink to [[Nowhere]]

--- a/src/preload/client/importer/test/other/chronicles/01931164-259e-7cf6-84e3-55ca38691342.md
+++ b/src/preload/client/importer/test/other/chronicles/01931164-259e-7cf6-84e3-55ca38691342.md
@@ -1,0 +1,10 @@
+---
+title: Document 2
+tags:
+  - devlog
+  - chronicles
+createdAt: 2024-11-09T14:46:36.190Z
+updatedAt: 2024-11-22T17:13:39.227Z
+---
+
+Wikilink to [[Document 1]] and a #customtag

--- a/src/preload/client/importer/test/util.ts
+++ b/src/preload/client/importer/test/util.ts
@@ -1,0 +1,221 @@
+import DB from "better-sqlite3";
+import { ipcRenderer } from "electron";
+import Store from "electron-store";
+import fs from "fs";
+import KnexConstructor, { Knex } from "knex";
+import { tmpdir } from "os";
+import path from "path";
+import util from "util";
+import { Files } from "../../../files";
+import { DocumentsClient } from "../../documents";
+import { FilesClient } from "../../files";
+import { ImporterClient } from "../../importer";
+import { JournalsClient } from "../../journals";
+import { PreferencesClient } from "../../preferences";
+import { SyncClient } from "../../sync";
+import { TagsClient } from "../../tags";
+import { IClient } from "../../types";
+
+export interface GenerateFileOptions {
+  filePath: string;
+  fileType: "mov" | "jpg" | "png" | "pdf" | "csv" | "webp";
+}
+
+const filetypes = ["mov", "jpg", "png", "pdf", "csv", "webp"];
+
+export type Client = Omit<IClient, "tests">;
+
+export interface ISetupResponse {
+  // initialized knex client, for asserting import tables, etc
+  knex: Knex;
+  // client with a temp database, settings, and notes directory
+  client: Client;
+  // import test directory
+  testdir: string;
+}
+
+function testDir() {
+  return path.relative(process.cwd(), "src/preload/client/importer/test");
+}
+
+// clean image files from the test directory
+export async function cleanup() {
+  let count = 0;
+  for await (const file of Files.walk(testDir(), 4, () => true)) {
+    if (filetypes.includes(path.extname(file.path).slice(1))) {
+      count++;
+      await fs.promises.unlink(file.path);
+    }
+
+    // sanity check
+    if (count > 10) {
+      throw new Error(
+        "Attempted to delete too many files in test direcotry; something is wrong. Last file: " +
+          file.path,
+      );
+    }
+  }
+}
+
+export const generateFileStubs = async (stubs: GenerateFileOptions[]) => {
+  await Promise.all(stubs.map(generateBinaryFileStub));
+};
+
+/**
+ * Generates a small, valid file of the specified type; for testing linked files imported
+ * alongside notes without having to track a bunch of binary files in Git.
+ */
+export const generateBinaryFileStub = async ({
+  filePath,
+  fileType,
+}: GenerateFileOptions): Promise<void> => {
+  // dumb: URLs in Notion documents are url encoded, but should not be on disk
+  // and assumed not to be in importer usage
+  filePath = decodeURIComponent(filePath);
+
+  filePath = path.join(testDir(), filePath);
+  const dir = path.dirname(filePath);
+
+  // todo: only necessary if directory structure not pre setup.
+  await Files.mkdirp(dir);
+
+  const ext = path.extname(filePath);
+  if (ext !== `.${fileType}`) {
+    throw new Error(`File extension does not match file type: ${fileType}`);
+  }
+
+  switch (fileType) {
+    case "mov":
+      fs.writeFileSync(filePath, Buffer.from("ftypisom", "utf-8")); // Minimal MOV header
+      break;
+    case "jpg":
+      fs.writeFileSync(
+        filePath,
+        Buffer.from([
+          0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00,
+          0x01,
+        ]),
+      );
+      break;
+    case "png":
+      fs.writeFileSync(
+        filePath,
+        Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+      );
+    case "pdf":
+      fs.writeFileSync(filePath, Buffer.from("%PDF-1.4\n%âãÏÓ", "utf-8")); // Minimal PDF header
+      break;
+    case "csv":
+      fs.writeFileSync(filePath, "column1,column2\nvalue1,value2"); // Basic CSV content
+      break;
+    case "webp":
+      fs.writeFileSync(filePath, Buffer.from("RIFF" + "WEBP", "utf-8"));
+      break;
+    default:
+      throw new Error(`Unsupported file type: ${fileType}`);
+  }
+};
+
+// create a client with a temp database, settings, and notes directory
+// for integration testing
+export async function setup(): Promise<ISetupResponse> {
+  const store = new Store({
+    name: "test",
+  });
+  store.reset();
+
+  const tempDir = fs.mkdtempSync(path.join(tmpdir(), "chronicles-test-"));
+
+  // Setup the test database URL and notes directory
+  const dbUrl = path.join(tempDir, "test.db");
+  const notesDir = path.join(tempDir, "notes");
+
+  // Ensure the notes notesDirdirectory exists
+  Files.mkdirp(notesDir);
+
+  store.set("NOTES_DIR", notesDir);
+
+  const { success, error } = await ipcRenderer.invoke("setup-database", dbUrl);
+
+  if (!success) {
+    console.error("Database setup failed:", dbUrl, error);
+    throw new Error("Database migration failed.");
+  }
+
+  const db = DB(dbUrl);
+  const knex = KnexConstructor({
+    client: "better-sqlite3", // or 'better-sqlite3'
+    connection: {
+      filename: dbUrl,
+    },
+    // https://knexjs.org/guide/query-builder.html#insert
+    // don't replace undefined with "DEFAULT" in insert statements; replace
+    // it with NULL instead (SQLite raises otherwise)
+    useNullAsDefault: true,
+  });
+
+  const preferences = new PreferencesClient(store);
+  const files = new FilesClient(store);
+  const journals = new JournalsClient(knex, files, preferences);
+  const documents = new DocumentsClient(db, knex, files, preferences);
+  const sync = new SyncClient(
+    db,
+    knex,
+    journals,
+    documents,
+    files,
+    preferences,
+  );
+
+  const importer = new ImporterClient(
+    knex,
+    documents,
+    files,
+    preferences,
+    sync,
+  );
+
+  const client = {
+    journals: journals,
+    documents: documents,
+    tags: new TagsClient(knex),
+    preferences: preferences,
+    files: files,
+    sync,
+    importer,
+  };
+
+  return { testdir: testDir(), client, knex };
+}
+
+// mocha setup + electron + esbuild -> fail. This is a workaround.
+export const test = async (name: string, fn: () => void | Promise<void>) => {
+  try {
+    await fn();
+    console.log(`✅ ${name}`);
+  } catch (err) {
+    console.error(`❌ ${name}`);
+    console.error(util.inspect(err, { depth: 5 }));
+  }
+};
+
+// find one by title, and raise helpfully if not found
+export async function findByTitle(client: Client, title: string) {
+  const docs = await client.documents.search({
+    journals: [],
+    titles: [title],
+  });
+
+  if (docs.data.length === 0) {
+    throw new Error(`Document not found by title: ${title}`);
+  }
+
+  const doc = await client.documents.findById({ id: docs.data[0].id });
+  if (!doc) {
+    throw new Error(
+      `Document not found by id: ${docs.data[0].id} (title: ${title})`,
+    );
+  }
+
+  return doc;
+}

--- a/src/preload/client/index.ts
+++ b/src/preload/client/index.ts
@@ -3,6 +3,7 @@ import Knex from "knex";
 import { DocumentsClient } from "./documents";
 import { FilesClient } from "./files";
 import { ImporterClient } from "./importer";
+import { runTests } from "./importer/test";
 import { JournalsClient } from "./journals";
 import { PreferencesClient } from "./preferences";
 import { SyncClient } from "./sync";
@@ -36,10 +37,12 @@ export { GetDocumentResponse } from "./types";
 
 let client: IClient;
 
+// no CI test runner for electron tests; so exposed via client so they can be called from the app
+// todo: run via cli, then via CI
 class TestsClient {
-  constructor(private importer: ImporterClient) {}
-  runTests = () => {
-    console.log("todo: fixme");
+  constructor() {}
+  runTests = async () => {
+    await runTests();
   };
 }
 
@@ -59,9 +62,7 @@ export function create(): IClient {
     );
 
     const importer = new ImporterClient(
-      db,
       knex,
-      journals,
       documents,
       files,
       preferences,
@@ -71,12 +72,12 @@ export function create(): IClient {
     client = {
       journals: journals,
       documents: documents,
-      tags: new TagsClient(db, knex),
+      tags: new TagsClient(knex),
       preferences: preferences,
       files: files,
       sync,
       importer,
-      tests: new TestsClient(importer),
+      tests: new TestsClient(),
     };
   }
 

--- a/src/preload/client/tags.ts
+++ b/src/preload/client/tags.ts
@@ -1,18 +1,11 @@
-import { Database } from "better-sqlite3";
 import { Knex } from "knex";
 
 export type ITagsClient = TagsClient;
 
 export class TagsClient {
-  constructor(
-    private db: Database,
-    private knex: Knex,
-  ) {}
+  constructor(private knex: Knex) {}
 
   all = async (): Promise<string[]> => {
-    return this.db
-      .prepare(`SELECT DISTINCT tag FROM document_tags`)
-      .all()
-      .map((row) => row.tag);
+    return this.knex("document_tags").distinct("tag").pluck("tag");
   };
 }

--- a/src/preload/files.ts
+++ b/src/preload/files.ts
@@ -138,10 +138,12 @@ export class Files {
   ): AsyncGenerator<PathStatsFile> {
     if (currentDepth > depthLimit) return;
 
+    // Ensure dir is absolute path
+    dir = path.resolve(dir);
+
     const dirHandle = await fs.promises.opendir(dir);
     for await (const entry of dirHandle) {
       const fullPath = path.join(dir, entry.name);
-
       // Skip hidden files/directories or other excluded names
       if (entry.isSymbolicLink()) continue; // Skip symlinks entirely
       if (!shouldIndex(entry)) continue;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2554,11 +2554,6 @@ deep-extend@^0.6.0:
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
   integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
-deep-object-diff@^1.1.9:
-  version "1.1.9"
-  resolved "https://registry.yarnpkg.com/deep-object-diff/-/deep-object-diff-1.1.9.tgz#6df7ef035ad6a0caa44479c536ed7b02570f4595"
-  integrity sha512-Rn+RuwkmkDwCi2/oXOFS9Gsr5lJZu/yTGpK7wAaAIE75CC+LCGEZHpY6VQJa/RoJcrmaA/docWJZvYohlNkWPA==
-
 defaults@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/defaults/-/defaults-1.0.3.tgz#c656051e9817d9ff08ed881477f3fe4019f3ef7d"


### PR DESCRIPTION
- refactor frontmatter tests to use mocha, generally cleaned up
- drop dependency deep object diff (now using chai diffs in only place it was used)
- add a basic integration style test for import process, currently run manually in app (since no mocha+electron setup, yet)
- fix bug where wikilinks would not convert on import, if front matter was also present
- refactor tags to knex

Little silly to run the tests with a button in preferences, but its exercises a fair amount of actual import logic, and caught a couple of bugs (fixed in this branch); so its definitely better than nothing. Future change can look at getting the tests running via cli command, in CI, and potentially using a real runner. The last attempt at using mocha (#199 ) was complicated and hit some snags

<img width="572" alt="Screenshot 2024-12-29 at 9 44 15 AM" src="https://github.com/user-attachments/assets/d196f95c-7538-4da1-86f9-18831f10b696" />


Closes #280 