### PR TITLE
add welcome screen

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,0 +1,56 @@
+import { Slot } from "@radix-ui/react-slot";
+import { cn } from "@udecode/cn";
+import { cva, type VariantProps } from "class-variance-authority";
+import * as React from "react";
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-primary text-primary-foreground shadow hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
+        outline:
+          "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
+        secondary:
+          "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-9 px-4 py-2",
+        sm: "h-8 rounded-md px-3 text-xs",
+        lg: "h-10 rounded-md px-8",
+        icon: "h-9 w-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button";
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
+Button.displayName = "Button";
+
+export { Button, buttonVariants };

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { cn } from "@udecode/cn";
+import { X } from "lucide-react";
+import * as React from "react";
+
+const Dialog = DialogPrimitive.Root;
+
+const DialogTrigger = DialogPrimitive.Trigger;
+
+const DialogPortal = DialogPrimitive.Portal;
+
+const DialogClose = DialogPrimitive.Close;
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className,
+    )}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-1.5 text-center sm:text-left",
+      className,
+    )}
+    {...props}
+  />
+);
+DialogHeader.displayName = "DialogHeader";
+
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className,
+    )}
+    {...props}
+  />
+);
+DialogFooter.displayName = "DialogFooter";
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className,
+    )}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescriptionMuted = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+
+DialogDescriptionMuted.displayName = DialogPrimitive.Description.displayName;
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm", className)}
+    {...props}
+  />
+));
+
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogDescriptionMuted,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+};

--- a/src/container.tsx
+++ b/src/container.tsx
@@ -25,8 +25,7 @@ export default observer(function Container() {
     );
   }
 
-  // todo: This loading error is ugly, and not very helpful. Why does it
-  // happen? Is it only journal loading errors?
+  // todo: This loading error is ugly, and not very helpful.
   if (loadingErr) {
     return (
       <LayoutDummy>

--- a/src/hooks/useApplicationLoader.ts
+++ b/src/hooks/useApplicationLoader.ts
@@ -24,6 +24,7 @@ export function useAppLoader() {
 
     async function load() {
       let toastId = null;
+
       try {
         if (await client.sync.needsSync()) {
           toastId = toast("Syncing notes database", {

--- a/src/preload/client/journals.ts
+++ b/src/preload/client/journals.ts
@@ -32,9 +32,8 @@ export class JournalsClient {
   };
 
   index = async (journalName: string): Promise<JournalResponse> => {
-    const existing = await this.preferences.get(
-      `ARCHIVED_JOURNALS.${journalName}`,
-    );
+    const archived = await this.preferences.get(`ARCHIVED_JOURNALS`);
+    const existing = journalName in archived;
 
     if (existing == null) {
       await this.preferences.set(`ARCHIVED_JOURNALS.${journalName}`, false);

--- a/src/preload/client/preferences.ts
+++ b/src/preload/client/preferences.ts
@@ -7,6 +7,7 @@ export interface Preferences {
   ARCHIVED_JOURNALS: Record<string, boolean>;
   NOTES_DIR: string;
   SETTINGS_DIR: string;
+  ONBOARDING: "new" | "complete";
 }
 
 const defaults = (): Preferences => ({
@@ -15,6 +16,7 @@ const defaults = (): Preferences => ({
   ARCHIVED_JOURNALS: {},
   NOTES_DIR: "",
   SETTINGS_DIR: "",
+  ONBOARDING: "new",
 });
 
 export type IPreferencesClient = PreferencesClient;
@@ -28,7 +30,7 @@ export class PreferencesClient {
     return this.settings.store as unknown as Preferences;
   };
 
-  get = async <T extends keyof Preferences>(key: T | string): Promise<any> => {
+  get = async (key: keyof Preferences): Promise<any> => {
     const setting = this.settings.get(key);
     return setting !== undefined
       ? setting

--- a/src/views/documents/welcome/index.tsx
+++ b/src/views/documents/welcome/index.tsx
@@ -1,0 +1,78 @@
+import { EditIcon, PanelStatsIcon, SettingsIcon } from "evergreen-ui";
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import { Button } from "../../../components/Button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "../../../components/Dialog";
+import useClient from "../../../hooks/useClient";
+
+export default function Welcome({ onComplete }: { onComplete: () => void }) {
+  const navigate = useNavigate();
+  const client = useClient();
+
+  function ackNewUser() {
+    onComplete();
+  }
+
+  return (
+    <Dialog defaultOpen={true} onOpenChange={ackNewUser}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Welcome to Chronicles!</DialogTitle>
+          <DialogDescription asChild>
+            <div>
+              <p>
+                The app organizes markdown notes into journals, sorting by time,
+                and has basic tagging and search features. To get started:
+              </p>
+
+              <ul className="my-6 ml-6 list-disc [&>li]:mt-2">
+                <li>
+                  Use <EditIcon className="mx-1 inline" /> to create a new note
+                </li>
+                <li>
+                  Use the sidebar <PanelStatsIcon className="mx-1 inline" /> to
+                  view and edit journals and #tags
+                </li>
+                <li>
+                  Use <SettingsIcon className="mx-1 inline" /> to import your
+                  existing markdown notes, or see where Chronicles stores its
+                  data{" "}
+                </li>
+              </ul>
+
+              <p>
+                The application is still in development, you can{" "}
+                <a
+                  className="font-medium text-primary underline underline-offset-4"
+                  href="https://github.com/cloverich/chronicles/releases"
+                >
+                  follow releases
+                </a>
+                &nbsp; for updates. If you have feedback, feel free to open an
+                issue on the Github repository - but check&nbsp;
+                <a
+                  className="font-medium text-primary underline underline-offset-4"
+                  href="https://github.com/cloverich/chronicles/issues/160"
+                >
+                  the roadmap
+                </a>
+                &nbsp;first!
+              </p>
+
+              <DialogClose asChild>
+                <Button type="button">Got it</Button>
+              </DialogClose>
+            </div>
+          </DialogDescription>
+        </DialogHeader>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/views/edit/editor/index.tsx
+++ b/src/views/edit/editor/index.tsx
@@ -2,5 +2,5 @@ import { PlateContent } from "@udecode/plate-common";
 import React from "react";
 
 export default function () {
-  return <PlateContent placeholder="Begin stream of conciousness..." />;
+  return <PlateContent />;
 }


### PR DESCRIPTION
- add new flag for first time use, and display a welcome screen on startup
- add Button and Dialog component
- remove placeholder text in editor, future change can auto focus on outside click

Adds a new settings key: `"ONBOARDING": "new"`. When new (not completed), start-up screen shows:

<img width="633" alt="Screenshot 2025-01-25 at 9 55 10 AM" src="https://github.com/user-attachments/assets/f999e907-1df2-4a15-987c-e81b82b55bd9" />


Closes #293
Closes #84