### PR TITLE
focus editor on outside click

### DIFF
--- a/src/views/edit/index.tsx
+++ b/src/views/edit/index.tsx
@@ -1,7 +1,9 @@
+import { useEditorRef } from "@udecode/plate-common";
 import { ChevronLeftIcon, IconButton, Pane } from "evergreen-ui";
 import { observer } from "mobx-react-lite";
 import React, { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
+import { ReactEditor } from "slate-react";
 import { JournalResponse } from "../../hooks/useClient";
 import { useJournals } from "../../hooks/useJournals";
 import Titlebar from "../../titlebar/macos";
@@ -17,6 +19,23 @@ import ReadOnlyTextEditor from "./editor/read-only-editor/ReadOnlyTextEditor";
 import { EditorToolbar } from "./editor/toolbar/EditorToolbar";
 import { EditLoadingComponent } from "./loading";
 import { useEditableDocument } from "./useEditableDocument";
+
+/**
+ * Helper for focusing the editor on click.
+ *
+ * Since the editor is styled to blend into the surrounding surfaces, some of which are just
+ * spacers for layout, it can be confusing to know where to click to focus the editor. Adding this handler
+ * onto the divs that should focus on click solves that. Note that, this hook MUST be used from components
+ * wrapped by <PlateContainer> or they will error.
+ */
+export function useFocusEditor() {
+  const editor = useEditorRef();
+  return (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+    if (e.target === e.currentTarget && !ReactEditor.isFocused(editor as any)) {
+      ReactEditor.focus(editor as any);
+    }
+  };
+}
 
 // Loads document, with loading and error placeholders
 const DocumentLoadingContainer = observer(() => {
@@ -85,6 +104,58 @@ const DocumentEditView = observer((props: DocumentEditProps) => {
     }
   }, []);
 
+  function goBack() {
+    if (
+      !document.dirty ||
+      confirm(
+        "Document is unsaved, exiting will discard document. Stop editing anyways?",
+      )
+    ) {
+      // This handles the edit case but hmm... if its new... it should be added to the search...
+      // but in what order? Well... if we aren't paginated... it should be at the top.
+      searchStore.updateSearch(document);
+      navigate(-1);
+    }
+  }
+
+  return (
+    <PlateContainer
+      document={document}
+      journals={journals}
+      saving={document.saving}
+      value={document.slateContent}
+      setValue={document.setSlateContent}
+      selectedEditorMode={selectedViewMode}
+      setSelectedEditorMode={setSelectedViewMode}
+    >
+      <EditorInner
+        document={document}
+        selectedViewMode={selectedViewMode}
+        setSelectedViewMode={setSelectedViewMode}
+        journals={journals}
+        goBack={goBack}
+      />
+    </PlateContainer>
+  );
+});
+
+// Moved from Container to support using useFocusEditor, which requires
+// component being wrapped in PlateContainer
+function EditorInner({
+  document,
+  selectedViewMode,
+  setSelectedViewMode,
+  journals,
+  goBack,
+}: {
+  document: EditableDocument;
+  selectedViewMode: EditorMode;
+  setSelectedViewMode: (mode: EditorMode) => void;
+  journals: JournalResponse[];
+  goBack: () => void;
+}) {
+  const focusEditor = useFocusEditor();
+
   function renderEditor(tab: string) {
     switch (tab) {
       case EditorMode.Editor:
@@ -116,68 +187,44 @@ const DocumentEditView = observer((props: DocumentEditProps) => {
     }
   }
 
-  function goBack() {
-    if (
-      !document.dirty ||
-      confirm(
-        "Document is unsaved, exiting will discard document. Stop editing anyways?",
-      )
-    ) {
-      // This handles the edit case but hmm... if its new... it should be added to the search...
-      // but in what order? Well... if we aren't paginated... it should be at the top.
-      searchStore.updateSearch(document);
-      navigate(-1);
-    }
-  }
-
   return (
-    <PlateContainer
-      document={document}
-      journals={journals}
-      saving={document.saving}
-      value={document.slateContent}
-      setValue={document.setSlateContent}
-      selectedEditorMode={selectedViewMode}
-      setSelectedEditorMode={setSelectedViewMode}
-    >
-      <Base.Container>
-        <Titlebar>
-          <IconButton
-            backgroundColor="transparent"
-            border="none"
-            icon={ChevronLeftIcon}
-            className="drag-none"
-            onClick={goBack}
-            marginRight={8}
-          >
-            Back to documents
-          </IconButton>
-          <Separator orientation="vertical" />
+    <Base.EditorContainer>
+      <Titlebar>
+        <IconButton
+          backgroundColor="transparent"
+          border="none"
+          icon={ChevronLeftIcon}
+          className="drag-none"
+          onClick={goBack}
+          marginRight={8}
+        >
+          Back to documents
+        </IconButton>
+        <Separator orientation="vertical" />
 
-          <EditorToolbar
-            selectedEditorMode={selectedViewMode}
-            setSelectedEditorMode={setSelectedViewMode}
-            document={document}
-          />
-        </Titlebar>
+        <EditorToolbar
+          selectedEditorMode={selectedViewMode}
+          setSelectedEditorMode={setSelectedViewMode}
+          document={document}
+        />
+      </Titlebar>
 
-        {/* This Ghost div is same height as titlebar, so pushes the main content below it -- necessary for the contents scrollbar to make sense */}
-        <Base.TitlebarSpacer />
-        <Base.ScrollContainer>
-          <Pane flexGrow={1} display="flex" flexDirection="column" width="100%">
-            <FrontMatter document={document} journals={journals} />
+      {/* This Ghost div is same height as titlebar, so pushes the main content below it -- necessary for the contents scrollbar to make sense */}
+      <Base.TitlebarSpacer />
+      <Base.ScrollContainer>
+        <Pane flexGrow={1} display="flex" flexDirection="column" width="100%">
+          <FrontMatter document={document} journals={journals} />
 
-            <Pane flexGrow={1} paddingTop={24}>
-              {renderEditor(selectedViewMode)}
-            </Pane>
-
-            {/* Add padding to bottom of editor without disrupting the scrollbar on the parent */}
-            <Base.BottomSpacer />
+          <Pane flexGrow={1} paddingTop={24} onClick={focusEditor}>
+            {renderEditor(selectedViewMode)}
           </Pane>
-        </Base.ScrollContainer>
-      </Base.Container>
-    </PlateContainer>
+
+          {/* Add padding to bottom of editor without disrupting the scrollbar on the parent */}
+          <Base.BottomSpacer onClick={focusEditor} />
+        </Pane>
+      </Base.ScrollContainer>
+    </Base.EditorContainer>
   );
-});
+}
 
 export default DocumentLoadingContainer;

--- a/src/views/layout.tsx
+++ b/src/views/layout.tsx
@@ -17,7 +17,24 @@ import React from "react";
  * </Base.Container>
  * ```
  */
-export const Container = ({ children }: React.PropsWithChildren) => {
+export const Container: React.FC<ClickableDivProps> = ({ children }) => {
+  return (
+    <div className="flex h-screen flex-col overflow-hidden">{children}</div>
+  );
+};
+
+const noop = () => {};
+
+/**
+ * For wrapping divs that are optionally clickable; specifically supporting
+ * the editor focus-on-click behavior, accounting for the fact that these wrappers
+ * are also used outside the editor page.
+ */
+interface ClickableDivProps extends React.HTMLAttributes<HTMLDivElement> {
+  onClick?: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
+}
+
+export const EditorContainer: React.FC<ClickableDivProps> = ({ children }) => {
   return (
     <div className="flex h-screen flex-col overflow-hidden">{children}</div>
   );
@@ -34,16 +51,22 @@ export const TitlebarSpacer = () => {
  * Add padding at the bottom of ScrollContainer without disrupting the scrollbar on the parent.
  * See Container for usage.
  */
-export const BottomSpacer = () => {
-  return <div className="h-16 min-h-16" />;
+export const BottomSpacer: React.FC<ClickableDivProps> = ({ onClick }) => {
+  return <div className="h-16 min-h-16" onClick={onClick || noop} />;
 };
 
 /**
  * Scrollable container for main content. See Container for usage.
  */
-export const ScrollContainer = ({ children }: React.PropsWithChildren) => {
+export const ScrollContainer: React.FC<ClickableDivProps> = ({
+  children,
+  onClick,
+}) => {
   return (
-    <div className="flex flex-grow flex-col overflow-y-scroll p-12">
+    <div
+      className="flex flex-grow flex-col overflow-y-scroll p-12"
+      onClick={onClick || noop}
+    >
       {children}
     </div>
   );


### PR DESCRIPTION
- when clicking surrounding div layout elements, focus the editor

Because the editor is styled to blend into the background, and the app has several layout spacers, it can be confusing to know where exactly to click to focus the editor. This will hopefully resolve this issue deifnitively.

Closes #302