### PR TITLE
improve document error handling

### DIFF
--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -1,4 +1,5 @@
 import { cva, type VariantProps } from "class-variance-authority";
+import { AngryIcon, InfoIcon, OctagonIcon, TriangleIcon } from "lucide-react";
 import * as React from "react";
 
 import { cn } from "@udecode/cn";
@@ -11,6 +12,8 @@ const alertVariants = cva(
         default: "bg-background text-foreground",
         destructive:
           "border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive",
+        warning: "border-warning/50 text-warning dark:border-warning",
+        error: "border-error/50 text-error dark:border-error",
       },
     },
     defaultVariants: {
@@ -19,7 +22,51 @@ const alertVariants = cva(
   },
 );
 
+const iconForVariant = {
+  default: InfoIcon,
+  destructive: OctagonIcon,
+  warning: TriangleIcon,
+  error: AngryIcon,
+};
+
+interface IAlert {
+  // variant: "default" | "destructive" | "warning" | "error";
+  title: string;
+}
+
 const Alert = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> &
+    VariantProps<typeof alertVariants> &
+    IAlert
+>(({ className, variant, title, children }, ref) => {
+  const Icon = iconForVariant[variant || "default"];
+  return (
+    <AlertBase ref={ref} variant={variant} className={className}>
+      <div className="flex">
+        {/* This worked ok to display Icon but layout wasn't great */}
+        {/* <div className="mr-2 h-6 w-6">
+          <Icon
+            strokeWidth={1}
+            className="mr-2 h-6 w-6"
+            size={32}
+            fontSize={32}
+            height={32}
+            width={32}
+          />
+        </div> */}
+        <div>
+          <AlertTitle>{title}</AlertTitle>
+          <AlertDescription>{children}</AlertDescription>
+        </div>
+      </div>
+    </AlertBase>
+  );
+});
+
+Alert.displayName = "Alert";
+
+const AlertBase = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
 >(({ className, variant, ...props }, ref) => (
@@ -30,21 +77,22 @@ const Alert = React.forwardRef<
     {...props}
   />
 ));
-Alert.displayName = "Alert";
+AlertBase.displayName = "AlertBase";
 
 const AlertTitle = React.forwardRef<
   HTMLParagraphElement,
   React.HTMLAttributes<HTMLHeadingElement>
 >(({ className, ...props }, ref) => (
-  <h5
+  <div
     ref={ref}
     className={cn(
-      "mb-1 mt-1 font-medium leading-none tracking-tight",
+      "mb-1 mt-1 text-lg font-medium leading-none tracking-tight",
       className,
     )}
     {...props}
   />
 ));
+
 AlertTitle.displayName = "AlertTitle";
 
 const AlertDescription = React.forwardRef<
@@ -59,4 +107,4 @@ const AlertDescription = React.forwardRef<
 ));
 AlertDescription.displayName = "AlertDescription";
 
-export { Alert, AlertDescription, AlertTitle };
+export { Alert, AlertBase, AlertDescription, AlertTitle };

--- a/src/error.tsx
+++ b/src/error.tsx
@@ -6,6 +6,10 @@ interface State {
   error: any;
 }
 
+interface Props {
+  children: React.ReactNode;
+}
+
 export default class ErrorBoundary extends React.Component<any, State> {
   constructor(props: any) {
     super(props);

--- a/src/views/edit/EditorErrorBoundary.tsx
+++ b/src/views/edit/EditorErrorBoundary.tsx
@@ -1,0 +1,134 @@
+import { ChevronLeftIcon, IconButton } from "evergreen-ui";
+import React from "react";
+import { NavigateFunction } from "react-router-dom";
+import { Alert } from "../../components";
+import Titlebar from "../../titlebar/macos";
+import * as Base from "../layout";
+import { Separator } from "./editor/components/Separator";
+
+interface State {
+  hasError: boolean;
+  error: any;
+}
+
+interface Props {
+  children: React.ReactNode;
+  navigate: NavigateFunction;
+  documentId: string;
+  journal: string;
+}
+
+/**
+ * Wraps the editor in an error boundary that catches and displays errors in an editor-friendly way.
+ */
+export default class EditorErrorBoundary extends React.Component<Props, State> {
+  constructor(props: any) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: any) {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: any, errorInfo: any) {
+    console.error(
+      "EditorErrorBoundary error boundary reached:",
+      error,
+      errorInfo,
+    );
+  }
+
+  renderError() {
+    const { errStr, stack } = decomposeError(this.state.error);
+
+    return (
+      <Base.EditorContainer>
+        <Titlebar>
+          <IconButton
+            backgroundColor="transparent"
+            border="none"
+            icon={ChevronLeftIcon}
+            className="drag-none"
+            onClick={() => this.props.navigate("/documents")}
+            marginRight={8}
+          >
+            Back to documents
+          </IconButton>
+          <Separator orientation="vertical" />
+        </Titlebar>
+
+        {/* This Ghost div is same height as titlebar, so pushes the main content below it -- necessary for the contents scrollbar to make sense */}
+        <Base.TitlebarSpacer />
+        <Base.ScrollContainer>
+          <ErrorContent
+            error={this.state.error}
+            journal={this.props.journal}
+            documentId={this.props.documentId}
+          />
+        </Base.ScrollContainer>
+      </Base.EditorContainer>
+    );
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.renderError();
+    }
+
+    return this.props.children;
+  }
+}
+
+export function decomposeError(error: any) {
+  let errStr: string = "Unable to parse error for display. Check console? :|";
+  let stack: string = "";
+  try {
+    if (error instanceof Error) {
+      errStr = error.message;
+      stack = error.stack || "";
+    } else if (typeof error === "string") {
+      errStr = error;
+    } else {
+      errStr = JSON.stringify(error, null, 2);
+    }
+    errStr = JSON.stringify(error, null, 2);
+  } catch (err) {
+    console.error("Error parsing error to string in top-level Error boundary");
+  }
+
+  return { errStr, stack };
+}
+
+export function ErrorContent({
+  error,
+  journal,
+  documentId,
+}: {
+  error: any;
+  journal?: string;
+  documentId?: string;
+}) {
+  const { errStr, stack } = decomposeError(error);
+
+  return (
+    <Alert.Alert
+      variant="error"
+      title="Unhandled Error"
+      className="overflow-x-auto"
+    >
+      <div>
+        <p>There was an error that crashed the editor</p>
+        {documentId && (
+          <p>
+            <span className="font-medium">Offending document:</span>{" "}
+            {journal || "Unknown Journal"}/{documentId}
+            .md
+          </p>
+        )}
+        {errStr && errStr != "{}" && <pre>{errStr}</pre>}
+        <pre>{stack}</pre>
+      </div>
+    </Alert.Alert>
+  );
+}

--- a/src/views/edit/loading.tsx
+++ b/src/views/edit/loading.tsx
@@ -1,12 +1,15 @@
-import { ChevronLeftIcon, IconButton, Pane } from "evergreen-ui";
+import { ChevronLeftIcon, IconButton } from "evergreen-ui";
 import { observer } from "mobx-react-lite";
 import React from "react";
 import { useNavigate } from "react-router-dom";
 import Titlebar from "../../titlebar/macos";
+import { ErrorContent } from "./EditorErrorBoundary";
 import { Separator } from "./editor/components/Separator";
 
 export interface LoadingComponentProps {
   error?: Error | null;
+  documentId?: string;
+  journal?: string;
 }
 
 export const placeholderDate = new Date().toISOString().slice(0, 10);
@@ -30,13 +33,13 @@ export const EditLoadingComponent = observer((props: LoadingComponentProps) => {
         </IconButton>
         <Separator orientation="vertical" />
       </Titlebar>
-      <Pane padding={50} paddingTop={98} flexGrow={1} display="flex">
-        <Pane flexGrow={1} display="flex" flexDirection="column" width="100%">
-          <Pane flexGrow={1} paddingTop={24}>
-            {props.error && props.error?.message}
-          </Pane>
-        </Pane>
-      </Pane>
+      {props.error && (
+        <ErrorContent
+          error={props.error}
+          journal={props.journal}
+          documentId={props.documentId}
+        />
+      )}
     </>
   );
 });

--- a/src/views/layout.tsx
+++ b/src/views/layout.tsx
@@ -64,7 +64,7 @@ export const ScrollContainer: React.FC<ClickableDivProps> = ({
 }) => {
   return (
     <div
-      className="flex flex-grow flex-col overflow-y-scroll p-12"
+      className="flex flex-grow flex-col overflow-y-auto p-12"
       onClick={onClick || noop}
     >
       {children}


### PR DESCRIPTION
- add better error display and ability to navigate when a document errors unexpectedly
- refactor Alert to simplify interface
- add better behavior when document not found (navigates back to homepage with toast); clean-up invalid error handling

Now displays the stack inside navigation, and outputs the document it tried to load. Alert is not pretty, but its better than it was (and also not evergreen, #215 )
<img width="794" alt="handled error" src="https://github.com/user-attachments/assets/1a2457ba-e9dc-4aba-aacd-f15b459fbb59" />

When document not found, instead of empty screen with a line of text, navigates back to documents search page with toast; this was the original intent but miscue on handling the not found error resulted in this being mixed up. 
<img width="422" alt="Screenshot 2025-02-03 at 11 51 59 AM" src="https://github.com/user-attachments/assets/cf8a9234-fc7d-45cb-82d8-acecc850a7e3" />

There's also some corrections to other kinds of errors being caught, but did not test these. 

Closes #260