### PR TITLE
remove google fonts; simplify fonts; increase csp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ tmp/
 dist/
 packaged/
 icons/out
+icons/src/temp-icon.png
 
 # bundler (dev) outputs .bundle files
 # along-side src files, used during development

--- a/src/index.css
+++ b/src/index.css
@@ -5,8 +5,8 @@
 /* This section initially added as recommended copypasta https://platejs.org/docs/components/installation/manual */
 @layer base {
   :root {
-    --font-sans: "Space Grotesk", sans-serif;
-    --font-heading: "Space Grotesk";
+    --font-sans: sans-serif;
+    --font-heading: sans-serif;
     --background: 0 0% 100%;
     --foreground: 222.2 84% 4.9%;
 

--- a/src/index.html
+++ b/src/index.html
@@ -6,7 +6,15 @@
     <link href="renderer.bundle.css" rel="stylesheet" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self' 'unsafe-inline'; media-src chronicles://* https://*; img-src chronicles://* https://* data:; style-src 'self' fonts.googleapis.com 'unsafe-inline'; font-src fonts.gstatic.com"
+      content="
+      default-src 'self';
+      script-src 'self';
+      style-src 'self' 'unsafe-inline';
+      img-src 'self' chronicles://* data:;
+      media-src chronicles://* https:;
+      font-src 'self';
+      connect-src 'self' chronicles://* https:;
+    "
     />
   </head>
 

--- a/src/typography.css
+++ b/src/typography.css
@@ -1,5 +1,6 @@
 html {
-  font-family: sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    "Helvetica Neue", Arial, sans-serif;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
 }
@@ -139,6 +140,7 @@ select {
 [type="submit"],
 button,
 html [type="button"] {
+  appearance: button;
   -webkit-appearance: button;
 }
 
@@ -188,6 +190,7 @@ textarea {
 }
 
 [type="search"] {
+  appearance: textfield;
   -webkit-appearance: textfield;
   outline-offset: -2px;
 }
@@ -240,21 +243,6 @@ html {
 body {
   color: hsla(0, 0%, 8%, 0.8);
   font-size: 0.9rem;
-  font-family:
-    "Space Grotesk",
-    sans-serif,
-    -apple-system,
-    "Roboto",
-    "Iosevka Aile",
-    "Iosevka Etoile",
-    "Iosevka",
-    "BlinkMacSystemFont",
-    "Segoe UI",
-    "Helvetica",
-    "Arial",
-    "Apple Color Emoji",
-    "Segoe UI Emoji",
-    "Segoe UI Symbol";
   font-weight: normal;
   word-wrap: break-word;
   font-kerning: normal;


### PR DESCRIPTION
- remove google fonts exceptions from content security policy
- tighten up overall content security policy; must leave unsafe-inline for styles until evergreen migration completed
- simplify fonts to just sans-serif; will make configurable in future release

At this point it probably makes sense to break #53 up into its remaining sub-components, which are lower priority and can be addressed alongside relevant changes. 

Closes #43
Part of #53