### PR TITLE
add placeholder for missing images

### DIFF
--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -43,7 +43,7 @@ const Alert = React.forwardRef<
   const Icon = iconForVariant[variant || "default"];
   return (
     <AlertBase ref={ref} variant={variant} className={className}>
-      <div className="flex">
+      <div className="flex overflow-auto">
         {/* This worked ok to display Icon but layout wasn't great */}
         {/* <div className="mr-2 h-6 w-6">
           <Icon


### PR DESCRIPTION
- add a placeholder when an image fails to load, and display the url the img element failed to fetch

Instead of a (small) blank space, user will now see this (plain) indicator that an image failed to load. 

<img width="685" alt="Screenshot 2025-03-29 at 3 46 06 PM" src="https://github.com/user-attachments/assets/2a79a77a-a12b-4547-8931-8e0b5931460c" />

Closes #257