### PR TITLE
feat: add image grouping

### DIFF
--- a/src/markdown/index.test.ts
+++ b/src/markdown/index.test.ts
@@ -213,7 +213,54 @@ describe("Slate processing", function () {
     });
   });
 
-  describe("Image links", function () {
+  describe("Images", function () {
+    // features/image-group
+    describe("image grouping", function () {
+      const doc = {
+        markdown:
+          "![75d97cd0e4b3f42f58aa80cefab00fec\\_res.jpeg](../_attachments/01931c56fdb076a292f80193b27f02bb.jpeg)\n![75d97cd0e4b3f42f58aa80cefab00fec\\_res.jpeg](../_attachments/01931c56fdb076a292f80193b27f02bb.jpeg)",
+        slate: [
+          {
+            type: "imageGroupElement",
+            children: [
+              {
+                type: "img",
+                url: "chronicles://../_attachments/01931c56fdb076a292f80193b27f02bb.jpeg",
+                title: undefined,
+                alt: "75d97cd0e4b3f42f58aa80cefab00fec_res.jpeg",
+                caption: [
+                  {
+                    text: "75d97cd0e4b3f42f58aa80cefab00fec_res.jpeg",
+                  },
+                ],
+                children: [
+                  {
+                    text: "",
+                  },
+                ],
+              },
+              {
+                type: "img",
+                url: "chronicles://../_attachments/01931c56fdb076a292f80193b27f02bb.jpeg",
+                title: undefined,
+                alt: "75d97cd0e4b3f42f58aa80cefab00fec_res.jpeg",
+                caption: [
+                  {
+                    text: "75d97cd0e4b3f42f58aa80cefab00fec_res.jpeg",
+                  },
+                ],
+                children: [
+                  {
+                    text: "",
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+    });
+
     describe("stand-alone images", function () {
       const doc = {
         markdown:
@@ -521,7 +568,7 @@ describe("Known issues / limitations", function () {
   // for whatever reason. Removing image unwrap fixes this problem (but introduces others), so I can try and re-wrap them then
   // use this test to verify the fix.
   it("does not collapse newlines when naked images", function () {
-    const markdown = `![alt text](https://example.com)\n\n![alt text](https://example.com)\n\n# Paragraph\n\nSome text\n`;
+    const markdown = `![alt text](https://example1.com)\n\n![alt text](https://example2.com)\n\n# Paragraph\n\nSome text\n`;
     const actual = slateToString(stringToSlate(markdown));
     expect(actual).to.equal(markdown);
   });

--- a/src/markdown/index.ts
+++ b/src/markdown/index.ts
@@ -22,36 +22,78 @@ import { ofmTag } from "./micromark-extension-ofm-tag";
 import { ofmWikilink } from "./micromark-extension-ofm-wikilink";
 import { mdastToSlate } from "./remark-slate-transformer/transformers/mdast-to-slate.js";
 
-// stand-alone images are parsed as paragraphs with a single image child; this
-// converts them to just the image node because in Slate rendering we don't want
-// imges to be children of paragraphs. But note this will confuse the mdast serializer
-function unwrapImages(tree: mdast.Root) {
-  tree.children = tree.children.map((child) => {
-    if (
-      child.type === "paragraph" &&
-      child.children.length === 1 &&
-      child.children[0].type === "image"
-    ) {
-      return child.children[0];
-    }
-    return child;
-  });
+// Needed because we augment mdast with the new imageGroupElement; see below. Note
+// this is the _documented_ way to extend mdast types.
+declare module "mdast" {
+  interface ImageGroupElement extends Literal {
+    type: "imageGroupElement";
+    children: Image[];
+  }
 
+  interface RootContentMap {
+    imageGroupElement: ImageGroupElement;
+  }
+}
+
+// The unwrap code below now handles both unwrapping images (legacy issue), and
+// converting consecutive images to image group elements. Ideally the imageGroupElement
+// concept exists in our custom slate dom and not mdast but its easiest to put it into
+// mdast for now, b/c of how the parsing is architected. Also, this module extension,
+// parsing, etc, should be moved to features/image-grouping or something.
+function unwrapAndGroupImagesSlate(tree: mdast.Root): mdast.Root {
+  const children: mdast.Content[] = [];
+  let imageNodes: mdast.Image[] = [];
+
+  const flushBuffer = () => {
+    if (imageNodes.length === 0) return;
+
+    if (imageNodes.length === 1) {
+      children.push(imageNodes[0]);
+    } else {
+      children.push({
+        type: "imageGroupElement",
+        children: imageNodes,
+      } as any); // Cast to any or extend mdast types
+    }
+
+    imageNodes = [];
+  };
+
+  for (const node of tree.children) {
+    if (
+      node.type === "paragraph" &&
+      node.children.length === 1 &&
+      node.children[0].type === "image"
+    ) {
+      // unwrap image nodes.
+      // stand-alone images are parsed as paragraphs with a single image child; this
+      // converts them to just the image node because in Slate rendering we don't want
+      // imges to be children of paragraphs. This process must be reversed when going
+      // back to mdast; see wrapImagesForMdast below.
+      imageNodes.push(node.children[0] as mdast.Image);
+    } else {
+      flushBuffer();
+      children.push(node);
+    }
+  }
+
+  flushBuffer();
+  tree.children = children;
   return tree;
 }
 
-// todo: Incorporate into mdast util properly, and do we need position nodes?
-// see unwrap images; we need to re-wrap top-level images with paragraphs otherwise
-// mdast-util-to-string FREAKS out and collapses all
-function wrapImages(tree: mdast.Root) {
-  tree.children = tree.children.map((child) => {
-    if (child.type === "image") {
+// reverse unwrapImages from above
+// todo: this was written prior to the micromark, still necessary?
+// todo: Is this code stripping relevant positioning information?
+function wrapImagesForMdast(tree: mdast.Root) {
+  tree.children = tree.children.map((node) => {
+    if (node.type === "image") {
       return {
         type: "paragraph",
-        children: [child],
+        children: [node],
       };
     }
-    return child;
+    return node;
   });
 
   return tree;
@@ -105,11 +147,11 @@ export const mdastToString = (tree: mdast.Nodes) => {
 // parser param: support configuring for importer tests, which import and convert
 // a few otherwise unsupported markdown features (tags, wikilinks)
 export const stringToSlate = (input: string, parse = parseMarkdown) => {
-  return mdastToSlate(unwrapImages(parse(input)));
+  return mdastToSlate(unwrapAndGroupImagesSlate(parse(input)));
 };
 
 export const slateToString = (nodes: SlateCustom.SlateNode[]) => {
-  return mdastToString(wrapImages(slateToMdast(nodes)));
+  return mdastToString(wrapImagesForMdast(slateToMdast(nodes)));
 };
 
 // is a markdown link a link to another note?

--- a/src/views/edit/PlateContainer.tsx
+++ b/src/views/edit/PlateContainer.tsx
@@ -108,6 +108,11 @@ import { useJournals } from "../../hooks/useJournals";
 import { SearchStore } from "../documents/SearchStore";
 import { EditableDocument } from "./EditableDocument";
 import { EditorMode } from "./EditorMode";
+import { createImageGroupPlugin } from "./editor/features/image-group";
+import {
+  ELEMENT_IMAGE_GROUP,
+  ImageGroupElement,
+} from "./editor/features/image-group/ImageGroupElement";
 
 export interface Props {
   saving: boolean;
@@ -166,6 +171,7 @@ export default observer(
         createFilesPlugin(),
         createNoteLinkDropdownPlugin({ options: { store } } as any),
         createNoteLinkElementPlugin(),
+        createImageGroupPlugin(),
 
         // Backspacing into an element selects the block before deleting it.
         createSelectOnBackspacePlugin({
@@ -291,7 +297,7 @@ export default observer(
         // being confused about how to exit an e.g. code block to add more content.
         createTrailingBlockPlugin({ type: ELEMENT_PARAGRAPH }),
 
-        // convert markdown to wysiwyg sa you type:
+        // convert markdown to wysiwyg as you type:
         // # -> h1, ``` -> code block, etc
         createAutoformatPlugin({
           options: {
@@ -315,6 +321,7 @@ export default observer(
           [ELEMENT_H5]: withProps(HeadingElement, { variant: "h5" }),
           [ELEMENT_H6]: withProps(HeadingElement, { variant: "h6" }),
           [ELEMENT_IMAGE]: ImageElement,
+          [ELEMENT_IMAGE_GROUP]: ImageGroupElement,
           [ELEMENT_LINK]: LinkElement,
 
           // NoteLinkDropdown provides the dropdown when typing `@`; NoteLinkElement

--- a/src/views/edit/editor/elements/ImageElement.tsx
+++ b/src/views/edit/editor/elements/ImageElement.tsx
@@ -21,13 +21,13 @@ export const ImageElement = ({
     url,
   } = useMediaState();
 
-  // When image fails to load, show a placeholder otherwise instead of the image, there's a small blank space
-  // and its not obvious anything is wrong, unless you know there is meant to be an image there.
+  // When image fails to load, show a placeholder
+  // Otherwise, its not obvious an image is missing (blank space)
   const [showPlaceholder, setShowPlaceholder] = React.useState(false);
 
   const handleError = (e: React.SyntheticEvent<HTMLImageElement>) => {
     // todo: Unsure how to distinguish a 404 from other errors; there will be an associated
-    // global GET error, but unclear if its tied to _this_ error.
+    // global GET error, but unclear if / how its tied to _this_ error.
     e.preventDefault();
     e.stopPropagation();
     setShowPlaceholder(true);

--- a/src/views/edit/editor/features/image-group/ImageGroupElement.tsx
+++ b/src/views/edit/editor/features/image-group/ImageGroupElement.tsx
@@ -1,0 +1,45 @@
+import { cn, withRef } from "@udecode/cn";
+import { PlateElement, TElement } from "@udecode/plate-common";
+import React from "react";
+
+export const ELEMENT_IMAGE_GROUP = "imageGroupElement";
+
+export interface IImageGroupElement extends TElement {
+  images: string[];
+}
+
+/**
+ * When multiple images appear consecutively in the document, they are grouped
+ * into an imageGroupElement node type (see parser). This component displays them
+ * as a gallery
+ */
+export const ImageGroupElement = withRef<typeof PlateElement>(
+  ({ className, children, ...props }, ref) => {
+    // const element = useElement<IImageGroupElement>();
+
+    return (
+      <PlateElement ref={ref} asChild {...props}>
+        <>
+          <div
+            className={cn(
+              "grid gap-2",
+              // Dynamic column counts depending on image counts
+              {
+                1: "grid-cols-1",
+                2: "grid-cols-2",
+                3: "grid-cols-3",
+                4: "grid-cols-2",
+                5: "grid-cols-3",
+              }[React.Children.count(children)] || "grid-cols-3",
+              "max-w-full",
+
+              className,
+            )}
+          >
+            {children}
+          </div>
+        </>
+      </PlateElement>
+    );
+  },
+);

--- a/src/views/edit/editor/features/image-group/createImageGroupElementPlugin.tsx
+++ b/src/views/edit/editor/features/image-group/createImageGroupElementPlugin.tsx
@@ -1,0 +1,9 @@
+import { createPluginFactory } from "@udecode/plate-common";
+
+import { ELEMENT_IMAGE_GROUP } from "./ImageGroupElement";
+
+export const createImageGroupPlugin = createPluginFactory({
+  isElement: true,
+  isInline: false,
+  key: ELEMENT_IMAGE_GROUP,
+});

--- a/src/views/edit/editor/features/image-group/index.ts
+++ b/src/views/edit/editor/features/image-group/index.ts
@@ -1,0 +1,12 @@
+export {
+  ELEMENT_IMAGE_GROUP,
+  IImageGroupElement,
+  ImageGroupElement,
+} from "./ImageGroupElement";
+
+export { createImageGroupPlugin } from "./createImageGroupElementPlugin";
+export {
+  SlateImageGroup,
+  createImageGroupElement,
+  createImagesFromImageGroup,
+} from "./toMdast";

--- a/src/views/edit/editor/features/image-group/toMdast.ts
+++ b/src/views/edit/editor/features/image-group/toMdast.ts
@@ -1,0 +1,51 @@
+import mdast from "mdast";
+import { BaseElement } from "../../../../../markdown/remark-slate-transformer/transformers/mdast-to-slate";
+import { ELEMENT_IMAGE_GROUP, IImageGroupElement } from "./ImageGroupElement";
+
+export function createImagesFromImageGroup(
+  node: IImageGroupElement,
+  convertNodes: any,
+): mdast.Image[] {
+  return convertNodes(node.children);
+}
+
+interface ImageGroupNode extends mdast.Parent {
+  /**
+   * Node type of mdast paragraph.
+   */
+  type: "imageGroupElement";
+  /**
+   * Children of paragraph.
+   */
+  children: mdast.PhrasingContent[];
+  /**
+   * Data associated with the mdast paragraph.
+   */
+  data?: any;
+}
+
+interface ToSlateImageGroup {
+  convertNodes: any;
+  deco: any;
+  node: ImageGroupNode;
+}
+
+export interface SlateImageGroup extends BaseElement {
+  type: "imageGroupElement";
+  title: string;
+}
+
+/**
+ * Converts a markdown link to a NoteLink, if it points to a markdown file.
+ */
+export function createImageGroupElement({
+  convertNodes,
+  node,
+  deco,
+}: ToSlateImageGroup): SlateImageGroup {
+  return {
+    type: ELEMENT_IMAGE_GROUP,
+    children: convertNodes(node.children, deco),
+    title: "",
+  };
+}

--- a/src/views/edit/editor/features/note-linking/NoteLinkElement.tsx
+++ b/src/views/edit/editor/features/note-linking/NoteLinkElement.tsx
@@ -1,11 +1,12 @@
 import { cn, withRef } from "@udecode/cn";
-import { PlateElement, TElement, useElement } from "@udecode/plate-common";
+import { PlateElement, useElement } from "@udecode/plate-common";
 import React from "react";
 import { useNavigate } from "react-router-dom";
+import { BaseElement } from "../../../../../markdown/remark-slate-transformer/transformers/mdast-to-slate";
 
 export const ELEMENT_NOTE_LINK = "noteLinkElement";
 
-export interface INoteLinkElement extends TElement {
+export interface INoteLinkElement extends BaseElement {
   title: string;
   noteId: string;
   journalName: string;

--- a/src/views/edit/editor/features/note-linking/toMdast.ts
+++ b/src/views/edit/editor/features/note-linking/toMdast.ts
@@ -1,5 +1,8 @@
 import mdast from "mdast";
-import { Node } from "slate";
+import {
+  BaseElement,
+  SlateNode,
+} from "../../../../../markdown/remark-slate-transformer/transformers/mdast-to-slate";
 import { ELEMENT_NOTE_LINK, INoteLinkElement } from "./NoteLinkElement";
 
 /**
@@ -10,7 +13,7 @@ import { ELEMENT_NOTE_LINK, INoteLinkElement } from "./NoteLinkElement";
  * (file) link. Note that _how_ they are encoded is tightly coupled to the feature, because
  * we expect to parse them back into NoteLinkElements.
  */
-export function toMdastLinkFactory(convertNodes: (nodes: Node[]) => any) {
+export function toMdastLinkFactory(convertNodes: (nodes: SlateNode[]) => any) {
   return function toMdastLink(node: INoteLinkElement): mdast.Link {
     const { title, noteId, journalName, children } = node;
 
@@ -25,7 +28,7 @@ export function toMdastLinkFactory(convertNodes: (nodes: Node[]) => any) {
       url,
       title,
       children: convertNodes(children), // as any as mdast.Link["children"],
-    } as any;
+    };
   };
 }
 
@@ -49,11 +52,19 @@ export function parseNoteLink(url: string) {
   return { noteId, journalName };
 }
 
-interface ToSlateLink {
+interface ToSlateNoteLink {
   url: string;
   convertNodes: any;
   deco: any;
   children: any;
+}
+
+export interface SlateNoteLink extends BaseElement {
+  type: "noteLinkElement";
+  title: string;
+  url: string;
+  noteId: string;
+  journalName: string;
 }
 
 /**
@@ -64,7 +75,7 @@ export function toSlateNoteLink({
   convertNodes,
   deco,
   children,
-}: ToSlateLink) {
+}: ToSlateNoteLink): SlateNoteLink | undefined {
   const res = parseNoteLink(url);
 
   if (res) {

--- a/src/views/edit/index.tsx
+++ b/src/views/edit/index.tsx
@@ -1,5 +1,5 @@
 import { useEditorRef } from "@udecode/plate-common";
-import { ChevronLeftIcon, IconButton, Pane } from "evergreen-ui";
+import { ChevronLeftIcon, IconButton } from "evergreen-ui";
 import { observer } from "mobx-react-lite";
 import React, { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
@@ -230,16 +230,16 @@ function EditorInner({
       {/* This Ghost div is same height as titlebar, so pushes the main content below it -- necessary for the contents scrollbar to make sense */}
       <Base.TitlebarSpacer />
       <Base.ScrollContainer>
-        <Pane flexGrow={1} display="flex" flexDirection="column" width="100%">
+        <div className="flex w-full flex-grow flex-col">
           <FrontMatter document={document} journals={journals} />
 
-          <Pane flexGrow={1} paddingTop={24} onClick={focusEditor}>
+          <div className="flex flex-grow pt-6" onClick={focusEditor}>
             {renderEditor(selectedViewMode)}
-          </Pane>
+          </div>
 
           {/* Add padding to bottom of editor without disrupting the scrollbar on the parent */}
           <Base.BottomSpacer onClick={focusEditor} />
-        </Pane>
+        </div>
       </Base.ScrollContainer>
     </Base.EditorContainer>
   );


### PR DESCRIPTION
- add basic image grouping when image elements appear consecutively in markdown
- refactor mdast transformer types

<img width="780" alt="image-groups" src="https://github.com/user-attachments/assets/68e41394-1ff3-4df6-ab15-5faefc4bc737" />


This is a basic, functional first step. Its very light on features:

- Images that are separated only by text group up into a gallery view
- Drag and dropping a new image onto the editor, near the gallery, will add it to the group
- Deleting space between paragraphs will group them up, but **only after the note is reloaded**

Will need to implement "backspace to add note to group" behavior, but it requires a more sophisticated change I don't know how to do yet, and this adds value as is. Will keep #267 open until implemented.

Most of #267 