### PR TITLE
fix: paragraph patching

### DIFF
--- a/src/views/edit/FrontMatter.tsx
+++ b/src/views/edit/FrontMatter.tsx
@@ -146,6 +146,19 @@ const FrontMatter = observer(
             prefixHash={true}
           />
         </div>
+        <div className="-mt-2 mb-4 flex justify-start pl-0.5 text-sm">
+          <pre className="text-xs">
+            {JSON.stringify(
+              {
+                id: document.id,
+                journal: document.journal,
+                ...document.frontMatter,
+              },
+              null,
+              2,
+            )}
+          </pre>
+        </div>
       </>
     );
   },


### PR DESCRIPTION
- when transforming to slate, ensure a trailing paragraph is always present in the final slate DOM
- when transforming to slate, ensure all top-level nodes are block level (paragraph), not leaf nodes


This changes helps ensure that notes with non-editable elements at the end, like images, still allow text to be entered. Prior to this change, refreshing the note, or selecting some elements and hitting cmd+enter, and other non intuitive work arounds existed. After this change they will hopefully be needed less often. 