### PR TITLE
feat: explain blocked images

### DIFF
--- a/src/views/edit/editor/elements/ImageElement.tsx
+++ b/src/views/edit/editor/elements/ImageElement.tsx
@@ -25,6 +25,9 @@ export const ImageElement = ({
   // Otherwise, its not obvious an image is missing (blank space)
   const [showPlaceholder, setShowPlaceholder] = React.useState(false);
 
+  // note: dictated by CSP policy; see index.html
+  const [isRemoteImage] = React.useState(url?.startsWith("http"));
+
   const handleError = (e: React.SyntheticEvent<HTMLImageElement>) => {
     // todo: Unsure how to distinguish a 404 from other errors; there will be an associated
     // global GET error, but unclear if / how its tied to _this_ error.
@@ -41,13 +44,24 @@ export const ImageElement = ({
       >
         {showPlaceholder ? (
           <div className="flex h-full w-full items-center justify-center rounded-sm bg-slate-200">
-            <Alert variant="warning" title="Missing image" className="mt-2">
-              <p>
-                There was an error loading this image. It may have been deleted
-                or moved?
-              </p>
-              <code className="mt-2 break-all">URL: {url}</code>
-            </Alert>
+            {isRemoteImage ? (
+              <Alert variant="warning" title="Blocked image" className="mt-2">
+                <p>
+                  Unable to load remote image. Remote images are not allowed by
+                  Chronicles. Download and copy the image into Chronicles
+                  instead.
+                </p>
+                <code className="mt-2 break-all">URL: {url}</code>
+              </Alert>
+            ) : (
+              <Alert variant="warning" title="Missing image" className="mt-2">
+                <p>
+                  There was an error loading this image. It may have been
+                  deleted or moved?
+                </p>
+                <code className="mt-2 break-all">URL: {url}</code>
+              </Alert>
+            )}
           </div>
         ) : (
           <img


### PR DESCRIPTION
- add a special case to the ImageElement placeholder that indicates when an image did not display because it was blocked

<img width="762" alt="blocked image" src="https://github.com/user-attachments/assets/5f3da684-991f-43ab-814e-44a09315dfdf" />


Chronicles already blocks loading of remote images via its CSP; now using the placeholder image, the blocked nature is indicated to the user. Handles only the most obvious cases (http(s) in url)


Closes #263