### PR TITLE
feat: track missing images

### DIFF
--- a/src/electron/migrations/20211005142122.sql
+++ b/src/electron/migrations/20211005142122.sql
@@ -50,6 +50,15 @@ CREATE TABLE IF NOT EXISTS "document_links" (
     PRIMARY KEY ("documentId", "targetId")
 );
 
+CREATE TABLE IF NOT EXISTS "image_links" (
+    "documentId" TEXT NOT NULL,
+    "imagePath" TEXT NOT NULL,
+    "resolved" BOOLEAN NOT NULL DEFAULT 0,
+    "lastChecked" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY ("documentId") REFERENCES "documents" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    PRIMARY KEY ("documentId", "imagePath")
+);
+
 CREATE TABLE IF NOT EXISTS "sync" (
     "id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     "startedAt" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -63,6 +72,8 @@ CREATE INDEX IF NOT EXISTS "document_links_target_idx" ON "document_links"("targ
 CREATE INDEX IF NOT EXISTS "documents_title_idx" ON "documents"("title");
 CREATE INDEX IF NOT EXISTS "documents_createdat_idx" ON "documents"("createdAt");
 CREATE INDEX IF NOT EXISTS "tags_name_idx" ON "document_tags"("tag");
+CREATE INDEX IF NOT EXISTS "image_links_path_idx" ON "image_links"("imagePath");
+CREATE INDEX IF NOT EXISTS "image_links_resolved_idx" ON "image_links"("resolved");
 
 
 -- DROP TABLE IF EXISTS "imports";
@@ -87,7 +98,6 @@ CREATE TABLE IF NOT EXISTS "import_files" (
     "error" TEXT
 );
 
--- First, Import Items table
 CREATE TABLE IF NOT EXISTS "import_notes" (
     "importerId" TEXT NOT NULL,
     "status" TEXT NOT NULL, -- success, error

--- a/src/preload/client/files.ts
+++ b/src/preload/client/files.ts
@@ -214,6 +214,7 @@ export class FilesClient {
       }
     } catch (err: any) {
       if (err.code !== "ENOENT" && propagateErr) throw err;
+      console.error("validFile error", err);
       return false;
     }
 
@@ -223,6 +224,7 @@ export class FilesClient {
       return true;
     } catch (err: any) {
       if (err.code !== "ENOENT" && propagateErr) throw err;
+      console.error("validFile error", err);
       return false;
     }
   };

--- a/src/preload/client/sync.ts
+++ b/src/preload/client/sync.ts
@@ -76,6 +76,7 @@ export class SyncClient {
     this.db.exec("delete from document_tags");
     this.db.exec("delete from documents");
     this.db.exec("delete from journals");
+    // image and note links delete via cascade
 
     const rootDir = await this.preferences.get("NOTES_DIR");
 
@@ -133,6 +134,7 @@ export class SyncClient {
           journal: dirname, // using name as id
           content: contents,
           frontMatter,
+          rootDir,
         });
         syncedCount++;
       } catch (e) {

--- a/src/preload/client/types.ts
+++ b/src/preload/client/types.ts
@@ -137,6 +137,7 @@ export interface IndexRequest {
   journal: string;
   content: string;
   frontMatter: FrontMatter;
+  rootDir: string;
 }
 
 // Nobody would put node_modules in their note directory... right?


### PR DESCRIPTION
- add table to track whether image references in notes are resolveable

Many of my older notes have invalid references, from the historical hacking in chronicles and other note taking applications. Additionally I want to build confidence Chronicles in its current form is not misplacing or failing to import images. This change adds a new table and tracks whether each added image is resolveable. Its done in a naive way and will further degrade sync performance, but this will be easy to optimize in a forthcoming performance sprint once the UX is fully worked out.

Closes #318 
Closes #319