### PR TITLE
fix: better image url validation

### DIFF
--- a/src/electron/index.js
+++ b/src/electron/index.js
@@ -76,15 +76,22 @@ app.whenReady().then(() => {
  * or missing files resolve to null; in testing, passing null to the protocol handler
  * results in 404's in img and video tags.
  *
- * @param {string} chroniclesUrl The "chronicles://" URL to convert.
+ * @param {string} chroniclesUrl The "chronicles://" URL to convert
  */
 function validateChroniclesUrl(chroniclesUrl) {
-  // strip the leading chronicles://, then convert to absolute url
-  // Also: file references are created with ../, because of the directory
-  // structure used by Chronicles. Strip the leading ../ since we are
-  // already in the root directory
+  // NOTE: chroniclesUrl SHOULD start with chronicles://../_attachments/<filename>
+  // NOTE: UI should also validate this, to tell user how to fix (if it comes up)
+  if (!chroniclesUrl?.startsWith("chronicles://../_attachments")) {
+    console.warn(
+      "chronicles:// file handler blocking access to file outside of _attachments directory",
+    );
+    return null;
+  }
+
+  // strip chronicles:// - so we can treat as a file path
+  // strip ../ - we prepend the root directory (NOTES_DIR) to make absolute path
   const url = decodeURI(chroniclesUrl.slice("chronicles://../".length));
-  const baseDir = settings.get("NOTES_DIR");
+  const baseDir = path.join(settings.get("NOTES_DIR"));
   const absPath = path.join(baseDir, url);
   const normalizedPath = path.normalize(absPath);
 

--- a/src/preload/client/documents.ts
+++ b/src/preload/client/documents.ts
@@ -321,7 +321,6 @@ export class DocumentsClient {
       }
 
       await this.addNoteLinks(trx, id, content);
-
       await this.addImageLinks(trx, id, content, rootDir, journal);
 
       return id;
@@ -333,6 +332,7 @@ export class DocumentsClient {
     journal,
     content,
     frontMatter,
+    rootDir,
   }: IndexRequest): Promise<void> => {
     return this.knex.transaction(async (trx) => {
       await trx("documents")
@@ -354,6 +354,7 @@ export class DocumentsClient {
 
       await trx("document_links").where({ documentId: id }).del();
       await this.addNoteLinks(trx, id!, content);
+      await this.addImageLinks(trx, id, content, rootDir, journal);
     });
   };
 

--- a/src/preload/client/files.ts
+++ b/src/preload/client/files.ts
@@ -114,7 +114,7 @@ export class FilesClient {
 
     const ext = path.parse(file.name).ext;
     const filename = `${createId()}${ext || ".unknown"}`;
-    const filepath = path.join(dir as string, filename);
+    const filepath = path.join(dir, filename);
     return new Promise<UploadResponse>((res, rej) => {
       const stream = fs.createWriteStream(filepath);
       // the fs write stream is not compatible with the input stream :(

--- a/src/views/edit/editor/elements/ImageElement.tsx
+++ b/src/views/edit/editor/elements/ImageElement.tsx
@@ -13,6 +13,27 @@ export const ImageElement = ({
   nodeProps,
   ...props
 }: PlateRenderElementProps) => {
+  return (
+    <MediaPopover pluginKey={ELEMENT_IMAGE}>
+      <PlateElement
+        className={cn("flex max-h-96 justify-start py-2.5", className)}
+        {...props}
+      >
+        <ImageElementInner />
+        {children}
+      </PlateElement>
+    </MediaPopover>
+  );
+};
+
+type ImageLoadStatus =
+  | "invalid_prefix"
+  | "remote_image"
+  | "valid"
+  | "loading"
+  | "not_found";
+
+const ImageElementInner = () => {
   const {
     readOnly,
     focused,
@@ -21,62 +42,77 @@ export const ImageElement = ({
     url,
   } = useMediaState();
 
-  // When image fails to load, show a placeholder
-  // Otherwise, its not obvious an image is missing (blank space)
-  const [showPlaceholder, setShowPlaceholder] = React.useState(false);
+  const [validStatus, setValidStatus] = React.useState<ImageLoadStatus>(() => {
+    if (!url) return "invalid_prefix";
+    if (url?.startsWith("http")) return "remote_image";
+    if (!url?.startsWith("chronicles://../_attachments"))
+      return "invalid_prefix";
 
-  // note: dictated by CSP policy; see index.html
-  const [isRemoteImage] = React.useState(url?.startsWith("http"));
+    return "loading";
+  });
+
+  const onLoad = (e: React.SyntheticEvent<HTMLImageElement>) => {
+    setValidStatus("valid");
+  };
 
   const handleError = (e: React.SyntheticEvent<HTMLImageElement>) => {
     // todo: Unsure how to distinguish a 404 from other errors; there will be an associated
     // global GET error, but unclear if / how its tied to _this_ error.
     e.preventDefault();
     e.stopPropagation();
-    setShowPlaceholder(true);
+    setValidStatus("not_found");
   };
 
-  return (
-    <MediaPopover pluginKey={ELEMENT_IMAGE}>
-      <PlateElement
-        className={cn("flex max-h-96 justify-start py-2.5", className)}
-        {...props}
-      >
-        {showPlaceholder ? (
-          <div className="flex h-full w-full items-center justify-center rounded-sm bg-slate-200">
-            {isRemoteImage ? (
-              <Alert variant="warning" title="Blocked image" className="mt-2">
-                <p>
-                  Unable to load remote image. Remote images are not allowed by
-                  Chronicles. Download and copy the image into Chronicles
-                  instead.
-                </p>
-                <code className="mt-2 break-all">URL: {url}</code>
-              </Alert>
-            ) : (
-              <Alert variant="warning" title="Missing image" className="mt-2">
-                <p>
-                  There was an error loading this image. It may have been
-                  deleted or moved?
-                </p>
-                <code className="mt-2 break-all">URL: {url}</code>
-              </Alert>
-            )}
-          </div>
-        ) : (
-          <img
-            src={url}
-            onError={handleError}
-            className={cn(
-              "max-h-full max-w-full cursor-pointer object-scale-down px-0",
-              "rounded-sm",
-              focused && selected && "ring-2 ring-ring ring-offset-2",
-            )}
-            alt=""
-          />
-        )}
-        {children}
-      </PlateElement>
-    </MediaPopover>
-  );
+  switch (validStatus) {
+    case "remote_image":
+      return (
+        <div className="flex h-full w-full items-center justify-center rounded-sm bg-slate-200">
+          <Alert variant="warning" title="Blocked image" className="mt-2">
+            <p>
+              Unable to load remote image. Remote images are not allowed by
+              Chronicles. Download and copy the image into Chronicles instead.
+            </p>
+            <code className="mt-2 break-all">URL: {url}</code>
+          </Alert>
+        </div>
+      );
+    case "not_found":
+      return (
+        <div className="flex h-full w-full items-center justify-center rounded-sm bg-slate-200">
+          <Alert variant="warning" title="Missing image" className="mt-2">
+            <p>
+              There was an error loading this image. It may have been deleted or
+              moved?
+            </p>
+            <code className="mt-2 break-all">URL: {url}</code>
+          </Alert>
+        </div>
+      );
+    case "invalid_prefix":
+      return (
+        <div className="flex h-full w-full items-center justify-center rounded-sm bg-slate-200">
+          <Alert variant="warning" title="Invalid prefix" className="mt-2">
+            <p>
+              Valid image urls must begin with: chronicles://../_attachments
+            </p>
+            <code className="mt-2 break-all">URL: {url}</code>
+          </Alert>
+        </div>
+      );
+    case "valid":
+    case "loading": // todo: something fancier
+      return (
+        <img
+          src={url}
+          onLoad={onLoad}
+          onError={handleError}
+          className={cn(
+            "max-h-full max-w-full cursor-pointer object-scale-down px-0",
+            "rounded-sm",
+            focused && selected && "ring-2 ring-ring ring-offset-2",
+          )}
+          alt=""
+        />
+      );
+  }
 };

--- a/src/views/edit/editor/plugins/createFilesPlugin.tsx
+++ b/src/views/edit/editor/plugins/createFilesPlugin.tsx
@@ -50,7 +50,6 @@ export const createFilesPlugin = createPluginFactory({
           }
         }
       } else {
-        // If it's not a file, delegate to the next plugin.
         insertData(dataTransfer);
       }
     };

--- a/src/views/edit/index.tsx
+++ b/src/views/edit/index.tsx
@@ -157,7 +157,6 @@ function EditorInner({
   journals: JournalResponse[];
   goBack: () => void;
 }) {
-  console.log("EditorInner.render");
   switch (selectedViewMode) {
     case EditorMode.Editor:
       return (


### PR DESCRIPTION
- detect invalid image url prefixes earlier in pipeline
- improve invalid image UI to detect invalid prefix (e.g. missing ../, missing _attachments) and inform user via invalid image alert

 Originally intended to fix image url pasting. As is, pasted images now validate and display correctly, and more robust paste support requires parsing pasted text as markdown, planned in a future feature

Closes #262 