### PR TITLE
fix: image drop normalization

### DIFF
--- a/src/views/edit/PlateContainer.tsx
+++ b/src/views/edit/PlateContainer.tsx
@@ -111,6 +111,7 @@ import {
   ELEMENT_IMAGE_GROUP,
   ImageGroupElement,
 } from "./editor/features/image-group/ImageGroupElement";
+import { createNormalizeImagesPlugin } from "./editor/plugins/createNormalizeImagesPlugin";
 
 export interface Props {
   saving: boolean;
@@ -154,6 +155,7 @@ export default observer(
             uploadImage: client.files.uploadImage,
           },
         }),
+        createNormalizeImagesPlugin(),
 
         // Plate's media handler turns youtube links, twitter links, etc, into embeds.
         // I'm unsure how to trigger the logic, probably via toolbar or shortcut.

--- a/src/views/edit/editor/plugins/createNormalizeImagesPlugin.tsx
+++ b/src/views/edit/editor/plugins/createNormalizeImagesPlugin.tsx
@@ -1,0 +1,35 @@
+import { PlatePlugin } from "@udecode/plate-core";
+import { ELEMENT_IMAGE } from "@udecode/plate-media";
+import { isElement } from "@udecode/slate";
+import { Editor, Transforms } from "slate";
+
+/**
+ * Ensure a dropped image is always at the top level of the document.
+ *
+ * @returns
+ */
+export const createNormalizeImagesPlugin = (): PlatePlugin => ({
+  key: "top-level-image-normalizer",
+  withOverrides: (editor) => {
+    // NOTE: As of now Chronicle sonly supports images as top-level elements, or as part of ImageGroupElements,
+    // not as children of others. I don't yet understand enough Slate / Plate to grasp the idiomatic approach here,
+    // this is my best guess a a solution, after discovering that dropping an image onto a node with a list
+    // would either rash the editor (earlier versions) or delete the image and the list item (as of writing).
+    const { normalizeNode } = editor;
+
+    editor.normalizeNode = ([node, path]) => {
+      if (isElement(node) && node.type === ELEMENT_IMAGE && path.length > 1) {
+        // Move to root
+        Transforms.removeNodes(editor as Editor, { at: path });
+        Transforms.insertNodes(editor as Editor, node, {
+          at: [editor.children.length],
+        });
+        return;
+      }
+
+      normalizeNode([node, path]);
+    };
+
+    return editor;
+  },
+});


### PR DESCRIPTION
- add a (hacky) normalization routine to move images dropped onto list items to the top level

Resolves an issue where dragging an image onto a list item (and probably other non-image elements) results in it being deleted, deleting the list item, or doing other wonky things

Closes #87 