### PR TITLE
fix: sharp is a prod dependency now

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "better-sqlite3": "^9.2.2",
     "electron-store": "^8.0.1",
     "knex": "^2.5.0",
+    "sharp": "^0.33.5",
     "uuid25": "^0.1.5",
     "uuidv7": "^0.6.3"
   },
@@ -77,7 +78,6 @@
     "react-dom": "^18.2.0",
     "react-hotkeys-hook": "^4.6.1",
     "react-router-dom": "^6.3.0",
-    "sharp": "^0.33.5",
     "slate": "^0.101.5",
     "slate-history": "^0.100.0",
     "slate-hyperscript": "^0.100.0",


### PR DESCRIPTION
- move sharp from dev to prod depeendencies, so it is packaged with the application

Note this adds an additional 17mb (ish) to the final build. May be able to reduce in #143 