### PR TITLE
refactor away from evergreen-ui

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "date-fns": "^3.3.1",
     "electron": "^28.2.0",
     "esbuild": "^0.20.0",
-    "evergreen-ui": "^7.1.9",
     "icon-gen": "^5.0.0",
     "lodash": "^4.17.21",
     "lucide-react": "^0.314.0",

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -1,9 +1,5 @@
-// NOTE: We also have the evergreen-ui Icons, which is what we use in the app
-// These were added to support latest plate versions, which use Lucide
-// icons in all their components. Will either prefer these throughou,
-// or migrate the plate icons to use evergreens
-// https://platejs.org/docs/components/installation/manual
 import { cva } from "class-variance-authority";
+
 import {
   AlignCenter,
   AlignJustify,
@@ -23,7 +19,6 @@ import {
   Combine,
   ExternalLink,
   Eye,
-  FileCode,
   FilePenLineIcon,
   Folder,
   FolderArchive,
@@ -61,6 +56,7 @@ import {
   Search,
   Settings,
   Smile,
+  SquareCode,
   Star,
   Strikethrough,
   Subscript,
@@ -191,6 +187,7 @@ export const Icons = {
   bug: Bug,
   check: Check,
   chevronDown: ChevronDown,
+  chevronLeft: ChevronLeft,
   "chevron-left": ChevronLeft,
   chevronUp: ChevronUp,
   chevronRight: ChevronRight,
@@ -198,7 +195,7 @@ export const Icons = {
   clear: X,
   close: X,
   code: Code2,
-  codeblock: FileCode,
+  codeblock: SquareCode,
   color: Baseline,
   column: RectangleVertical,
   combine: Combine,
@@ -230,6 +227,7 @@ export const Icons = {
   outdent: Outdent,
   paragraph: Pilcrow,
   "panel-right": PanelRight,
+  panelRight: PanelRight,
   refresh: RotateCcw,
   row: RectangleHorizontal,
   search: Search,

--- a/src/container.tsx
+++ b/src/container.tsx
@@ -1,8 +1,8 @@
-import { Alert } from "evergreen-ui";
 import { observer } from "mobx-react-lite";
 import React from "react";
 import "react-day-picker/dist/style.css";
 import { Navigate, Route, Routes } from "react-router-dom";
+import { Alert } from "./components";
 import {
   ApplicationContext,
   ApplicationState,
@@ -49,9 +49,14 @@ export default observer(function Container() {
   if (store.loadingErr) {
     return (
       <LayoutDummy>
-        <Alert intent="danger" title="Journals failed to load">
-          Journals failed to load: ${JSON.stringify(store.loadingErr)}
-        </Alert>
+        <Alert.Alert
+          variant="error"
+          title="Journals failed to load"
+          className="overflow-x-auto"
+        >
+          <p>Journals failed to load: </p>
+          <pre>${JSON.stringify(store.loadingErr, null, 2)}</pre>
+        </Alert.Alert>
       </LayoutDummy>
     );
   }

--- a/src/error.tsx
+++ b/src/error.tsx
@@ -1,5 +1,5 @@
-import { Alert, Pane } from "evergreen-ui";
 import React from "react";
+import { Alert } from "./components";
 
 interface State {
   hasError: boolean;
@@ -46,13 +46,17 @@ export default class ErrorBoundary extends React.Component<any, State> {
     }
 
     return (
-      <Pane padding={50}>
-        <Alert intent="danger" title="Unhandled Error" overflow="auto">
+      <div className="p-12">
+        <Alert.Alert
+          variant="error"
+          title="Unhandled Error"
+          className="overflow-x-auto"
+        >
           <p>There was an unhandled error that crashed the app</p>
           <pre>{errStr}</pre>
           <pre>{stack}</pre>
-        </Alert>
-      </Pane>
+        </Alert.Alert>
+      </div>
     );
   }
 

--- a/src/views/documents/index.tsx
+++ b/src/views/documents/index.tsx
@@ -1,8 +1,8 @@
-import { Heading, Pane, Paragraph } from "evergreen-ui";
 import { observer } from "mobx-react-lite";
 import React from "react";
 
 import { useNavigate } from "react-router-dom";
+import { Alert } from "../../components";
 import useClient from "../../hooks/useClient";
 import { useJournals } from "../../hooks/useJournals";
 import { DocumentItem } from "./DocumentItem";
@@ -50,7 +50,13 @@ function DocumentsContainer() {
   if ((searchStore.loading || onboardingLoading) && !searchStore.docs.length) {
     return (
       <Layout store={searchStore} empty>
-        <Heading>Loading</Heading>
+        <Alert.Alert
+          variant="default"
+          title="Loading documents"
+          className="overflow-x-auto"
+        >
+          <p>...</p>
+        </Alert.Alert>
       </Layout>
     );
   }
@@ -68,8 +74,14 @@ function DocumentsContainer() {
   if (searchStore.error) {
     return (
       <Layout store={searchStore}>
-        <Heading>Error</Heading>
-        <Paragraph>{JSON.stringify(searchStore.error)}</Paragraph>
+        <Alert.Alert
+          variant="error"
+          title="Search failed"
+          className="overflow-x-auto"
+        >
+          <p>Search failed: </p>
+          <pre>{JSON.stringify(searchStore.error, null, 2)}</pre>
+        </Alert.Alert>
       </Layout>
     );
   }
@@ -81,17 +93,27 @@ function DocumentsContainer() {
     if (journalsStore.journals.length) {
       return (
         <Layout store={searchStore}>
-          <Heading>No documents found</Heading>
-          <Paragraph>Broaden your search, or add more notes.</Paragraph>
+          <Alert.Alert
+            variant="default"
+            title="No documents found"
+            className="overflow-x-auto"
+          >
+            <p>Broaden your search, or add more notes.</p>
+          </Alert.Alert>
         </Layout>
       );
     } else {
       return (
         <Layout store={searchStore} empty>
-          <Heading>No journals added</Heading>
-          <Paragraph>
-            Use the preferences link in the navbar to create a new journal.
-          </Paragraph>
+          <Alert.Alert
+            variant="default"
+            title="No journals added"
+            className="overflow-x-auto"
+          >
+            <p>
+              Use the preferences link in the navbar to create a new journal.
+            </p>
+          </Alert.Alert>
         </Layout>
       );
     }
@@ -147,10 +169,10 @@ function Pagination(props: { store: SearchStore }) {
   })();
 
   return (
-    <Pane display="flex" justifyContent="flex-end" marginTop="24px">
+    <div className="flex-end mt-6 flex">
       {prevButton}
       {nextButton}
-    </Pane>
+    </div>
   );
 }
 

--- a/src/views/documents/welcome/index.tsx
+++ b/src/views/documents/welcome/index.tsx
@@ -1,4 +1,3 @@
-import { EditIcon, PanelStatsIcon, SettingsIcon } from "evergreen-ui";
 import React from "react";
 import { Button } from "../../../components/Button";
 import {
@@ -9,6 +8,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "../../../components/Dialog";
+import { Icons } from "../../../components/icons";
 
 export default function Welcome({ onComplete }: { onComplete: () => void }) {
   function ackNewUser() {
@@ -29,14 +29,15 @@ export default function Welcome({ onComplete }: { onComplete: () => void }) {
 
               <ul className="my-6 ml-6 list-disc [&>li]:mt-2">
                 <li>
-                  Use <EditIcon className="mx-1 inline" /> to create a new note
+                  Use <Icons.editing className="mx-1 inline" /> to create a new
+                  note
                 </li>
                 <li>
-                  Use the sidebar <PanelStatsIcon className="mx-1 inline" /> to
-                  view and edit journals and #tags
+                  Use the sidebar <Icons.panelRight className="mx-1 inline" />{" "}
+                  to view and edit journals and #tags
                 </li>
                 <li>
-                  Use <SettingsIcon className="mx-1 inline" /> to import your
+                  Use <Icons.settings className="mx-1 inline" /> to import your
                   existing markdown notes, or see where Chronicles stores its
                   data{" "}
                 </li>

--- a/src/views/edit/editor/components/Toolbar.tsx
+++ b/src/views/edit/editor/components/Toolbar.tsx
@@ -26,11 +26,13 @@ export const ToolbarSeparator = withCn(
   "my-1 w-[1px] shrink-0 bg-border",
 );
 
+// todo: Merge these variant classes with IconButton, and / or merge IconButton and
+// ToolbarButton.
 const toolbarButtonVariants = cva(
   cn(
     "inline-flex items-center justify-center text-xs ring-offset-background transition-colors disabled:pointer-events-none disabled:opacity-50",
     "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-    "[&_svg:not([data-icon])]:h-5 [&_svg:not([data-icon])]:w-5",
+    // "[&_svg:not([data-icon])]:h-5 [&_svg:not([data-icon])]:w-5",
     "rounded-sm border border-transparent",
   ),
   {
@@ -46,6 +48,7 @@ const toolbarButtonVariants = cva(
         xs: "h-5 p-1.5",
         sm: "h-7 p-1.5",
         lg: "h-9 p-1.5",
+        inherit: null,
       },
     },
     defaultVariants: {

--- a/src/views/edit/editor/toolbar/EditorToolbar.tsx
+++ b/src/views/edit/editor/toolbar/EditorToolbar.tsx
@@ -14,14 +14,6 @@ import { Toolbar, ToolbarGroup } from "../components/Toolbar";
 import { LinkToolbarButton } from "./components/LinkToolbarButton";
 import { MarkToolbarButton } from "./components/MarkToolbarButton";
 
-// I think this needs to be on the root, wherever Theme would be added (if we had a theme)
-import {
-  BoldIcon,
-  CodeIcon,
-  ItalicIcon,
-  StrikethroughIcon,
-  UnderlineIcon,
-} from "evergreen-ui";
 import { useNavigate } from "react-router-dom";
 import { useIsMounted } from "../../../../hooks/useIsMounted";
 import { useSearchStore } from "../../../documents/SearchStore";
@@ -78,32 +70,34 @@ export function EditorToolbar({
             <Toolbar>
               <ToolbarGroup className="drag-none">
                 <ChangeBlockDropdown />
-                <MarkToolbarButton tooltip="Bold (⌘+B)" nodeType={MARK_BOLD}>
-                  <BoldIcon size={16} />
-                </MarkToolbarButton>
+                <MarkToolbarButton
+                  size="inherit"
+                  tooltip="Bold (⌘+B)"
+                  nodeType={MARK_BOLD}
+                  icon="bold"
+                />
                 <MarkToolbarButton
                   tooltip="Italic (⌘+I)"
                   nodeType={MARK_ITALIC}
-                >
-                  <ItalicIcon size={16} />
-                </MarkToolbarButton>
+                  icon="italic"
+                />
                 <MarkToolbarButton
                   tooltip="Underline (⌘+U)"
                   nodeType={MARK_UNDERLINE}
-                >
-                  <UnderlineIcon size={16} />
-                </MarkToolbarButton>
+                  icon="underline"
+                />
 
                 <>
                   <MarkToolbarButton
                     tooltip="Strikethrough (⌘+⇧+M)"
                     nodeType={MARK_STRIKETHROUGH}
-                  >
-                    <StrikethroughIcon size={16} />
-                  </MarkToolbarButton>
-                  <MarkToolbarButton tooltip="Code (⌘+E)" nodeType={MARK_CODE}>
-                    <CodeIcon size={16} />
-                  </MarkToolbarButton>
+                    icon="strikethrough"
+                  />
+                  <MarkToolbarButton
+                    tooltip="Code (⌘+E)"
+                    nodeType={MARK_CODE}
+                    icon="code"
+                  />
                 </>
                 <LinkToolbarButton />
               </ToolbarGroup>

--- a/src/views/edit/editor/toolbar/components/ChangeBlockDropdown.tsx
+++ b/src/views/edit/editor/toolbar/components/ChangeBlockDropdown.tsx
@@ -25,17 +25,6 @@ import {
 } from "@udecode/plate-common";
 
 import {
-  CitationIcon,
-  CodeBlockIcon,
-  HeaderOneIcon,
-  HeaderThreeIcon,
-  HeaderTwoIcon,
-  NumberedListIcon,
-  ParagraphIcon,
-  PropertiesIcon,
-} from "evergreen-ui";
-
-import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuLabel,
@@ -44,54 +33,55 @@ import {
   DropdownMenuTrigger,
   useOpenState,
 } from "../../../../../components/DropdownMenu";
+import { Icons } from "../../../../../components/icons";
 import { ToolbarButton } from "../../components/Toolbar";
 
 const items = [
   {
     description: "Paragraph",
-    icon: ParagraphIcon,
+    icon: Icons.paragraph,
     label: "Paragraph",
     value: ELEMENT_PARAGRAPH,
   },
   {
     description: "Heading 1",
-    icon: HeaderOneIcon,
+    icon: Icons.h1,
     label: "Heading 1",
     value: ELEMENT_H1,
   },
   {
     description: "Heading 2",
-    icon: HeaderTwoIcon,
+    icon: Icons.h2,
     label: "Heading 2",
     value: ELEMENT_H2,
   },
   {
     description: "Heading 3",
-    icon: HeaderThreeIcon,
+    icon: Icons.h3,
     label: "Heading 3",
     value: ELEMENT_H3,
   },
   {
     description: "Quote (⌘+⇧+.)",
-    icon: CitationIcon,
+    icon: Icons.blockquote,
     label: "Quote",
     value: ELEMENT_BLOCKQUOTE,
   },
   {
     description: "Code (```)",
-    icon: CodeBlockIcon,
+    icon: Icons.codeblock,
     label: "Code",
     value: ELEMENT_CODE_BLOCK,
   },
   {
     description: "Bulleted list",
-    icon: PropertiesIcon,
+    icon: Icons.ul,
     label: "Bulleted list",
     value: ELEMENT_UL,
   },
   {
     description: "Numbered list",
-    icon: NumberedListIcon,
+    icon: Icons.ol,
     label: "Numbered list",
     value: ELEMENT_OL,
   },
@@ -139,7 +129,7 @@ export default function ChangeBlockDropdown(props: DropdownMenuProps) {
           pressed={openState.open}
           tooltip="Change type"
         >
-          <SelectedItemIcon className="size-5 lg:hidden" />
+          <SelectedItemIcon size={16} />
           <span className="max-lg:hidden">{selectedItemLabel}</span>
         </ToolbarButton>
       </DropdownMenuTrigger>
@@ -174,7 +164,7 @@ export default function ChangeBlockDropdown(props: DropdownMenuProps) {
               key={itemValue}
               value={itemValue}
             >
-              <Icon className="mr-2 size-5" />
+              <Icon className="mr-2" size={16} />
               {label}
             </DropdownMenuRadioItem>
           ))}

--- a/src/views/edit/editor/toolbar/components/DebugDropdown.tsx
+++ b/src/views/edit/editor/toolbar/components/DebugDropdown.tsx
@@ -11,11 +11,9 @@ import {
   DropdownMenuTrigger,
   useOpenState,
 } from "../../../../../components/DropdownMenu";
-import { ToolbarButton } from "../../components/Toolbar";
-
-import { MoreIcon, TrashIcon } from "evergreen-ui";
-
+import { Icons } from "../../../../../components/icons";
 import { EditorMode } from "../../../EditorMode";
+import { ToolbarButton } from "../../components/Toolbar";
 
 const options = Object.freeze([
   { key: EditorMode.Editor, label: "Editor" },
@@ -49,7 +47,7 @@ export default function DebugDropdown({
           tooltip="Change editor debug mode"
           size="xs"
         >
-          <MoreIcon className="ml-1 h-4 w-4" />
+          <Icons.more className="ml-1 h-4 w-4" />
         </ToolbarButton>
       </DropdownMenuTrigger>
 
@@ -77,7 +75,7 @@ export default function DebugDropdown({
 
         <DropdownMenuSeparator />
         <DropdownMenuItem onClick={deleteDocument}>
-          <TrashIcon size={16} />
+          <Icons.trash className="ml-1 h-4 w-4" />
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/src/views/edit/editor/toolbar/components/LinkToolbarButton.tsx
+++ b/src/views/edit/editor/toolbar/components/LinkToolbarButton.tsx
@@ -5,7 +5,7 @@ import {
 } from "@udecode/plate";
 import React from "react";
 
-import { LinkIcon } from "evergreen-ui";
+import { Icons } from "../../../../../components/icons";
 import { ToolbarButton } from "../../components/Toolbar";
 
 export const LinkToolbarButton = withRef<typeof ToolbarButton>((rest, ref) => {
@@ -14,7 +14,7 @@ export const LinkToolbarButton = withRef<typeof ToolbarButton>((rest, ref) => {
 
   return (
     <ToolbarButton ref={ref} tooltip="Link" {...props} {...rest}>
-      <LinkIcon size={16} />
+      <Icons.link size={16} />
     </ToolbarButton>
   );
 });

--- a/src/views/edit/editor/toolbar/components/MarkToolbarButton.tsx
+++ b/src/views/edit/editor/toolbar/components/MarkToolbarButton.tsx
@@ -4,6 +4,7 @@ import {
   useMarkToolbarButtonState,
 } from "@udecode/plate-common";
 import React from "react";
+import { Icons } from "../../../../../components/icons";
 import { ToolbarButton } from "../../components/Toolbar";
 
 /**
@@ -16,11 +17,17 @@ export const MarkToolbarButton = withRef<
   typeof ToolbarButton,
   {
     nodeType: string;
+    icon: keyof typeof Icons;
     clear?: string | string[];
   }
->(({ clear, nodeType, ...rest }, ref) => {
+>(({ icon, clear, nodeType, ...rest }, ref) => {
   const state = useMarkToolbarButtonState({ clear, nodeType });
   const { props } = useMarkToolbarButton(state);
+  const Icon = Icons[icon];
 
-  return <ToolbarButton ref={ref} {...props} {...rest} />;
+  return (
+    <ToolbarButton ref={ref} {...props} {...rest} size="inherit">
+      <Icon size={16} />
+    </ToolbarButton>
+  );
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -121,21 +121,7 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.23.9.tgz#7b903b6149b0f8fa7ad564af646c4c38a77fc44b"
   integrity sha512-9tcKgqKbs3xGJ+NtKF2ndOBBLVwPjl1SHxPQkd36r3Dlirw3xWUeGaTbqr7uGZcTaxkVNwc+03SVP7aCdWrTlA==
 
-"@babel/runtime@^7.1.2":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.10.4.tgz#a6724f1a6b8d2f6ea5236dbfe58c7d7ea9c5eb99"
-  integrity sha512-UpTN5yUJr9b4EX2CnGNWIvER7Ab83ibv0pcvvHc4UOdrBI5jb8bj+32cCwPX6xu0mt2daFNjYhoi+X7beH0RSw==
-  dependencies:
-    regenerator-runtime "^0.13.4"
-
-"@babel/runtime@^7.10.2":
-  version "7.15.4"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.15.4.tgz#fd17d16bfdf878e6dd02d19753a39fa8a8d9c84a"
-  integrity sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==
-  dependencies:
-    regenerator-runtime "^0.13.4"
-
-"@babel/runtime@^7.13.10", "@babel/runtime@^7.23.7", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.7":
+"@babel/runtime@^7.13.10", "@babel/runtime@^7.23.7":
   version "7.23.8"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.8.tgz#8ee6fe1ac47add7122902f257b8ddf55c898f650"
   integrity sha512-Y7KbAP984rn1VGMbGqKmBLio9V7y5Je9GvU4rQPCPinCyNfUcToxIXl06d59URp/F3LwinvODxab5N/G6qggkw==
@@ -341,11 +327,6 @@
   integrity sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==
   dependencies:
     tslib "^2.4.0"
-
-"@emotion/hash@^0.7.1":
-  version "0.7.4"
-  resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.7.4.tgz#f14932887422c9056b15a8d222a9074a7dfa2831"
-  integrity sha512-fxfMSBMX3tlIbKUdtGKxqB1fyrH6gVrX39Gsv3y8lRYKUqlgDt3UMqQyGnR1bQMa2B8aGnhLZokZgg8vT0Le+A==
 
 "@emotion/is-prop-valid@^0.8.8":
   version "0.8.8"
@@ -1512,13 +1493,6 @@
   resolved "https://registry.yarnpkg.com/@radix-ui/rect/-/rect-1.1.0.tgz#f817d1d3265ac5415dadc67edab30ae196696438"
   integrity sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg==
 
-"@segment/react-tiny-virtual-list@^2.2.1":
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/@segment/react-tiny-virtual-list/-/react-tiny-virtual-list-2.2.1.tgz#658da8a93cfb83537235c89307818d6f1741aeb3"
-  integrity sha512-G01b9DrsQLF+8yFRyyJeZBZkzbFuqILG9C7SFFS+GtTFbjdprkHt0CL0riCPOZfe1ZXiT8z8MaKoWfNhrfUjhQ==
-  dependencies:
-    prop-types "^15.5.7"
-
 "@sindresorhus/is@^4.0.0":
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.2.0.tgz#667bfc6186ae7c9e0b45a08960c551437176e1ca"
@@ -1649,13 +1623,6 @@
   version "18.2.18"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.18.tgz#16946e6cd43971256d874bc3d0a72074bb8571dd"
   integrity sha512-TJxDm6OfAX2KJWJdMEVTwWke5Sc/E/RlnPGvGfS0W7+6ocy2xhDVQVh/KvC2Uf7kACs+gDytdusDSdWfWkaNzw==
-  dependencies:
-    "@types/react" "*"
-
-"@types/react-transition-group@^4.4.0":
-  version "4.4.10"
-  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.10.tgz#6ee71127bdab1f18f11ad8fb3322c6da27c327ac"
-  integrity sha512-hT/+s0VQs2ojCX823m60m5f0sL5idt9SO6Tj6Dg+rdphGPIeJbJ6CxvBYkgkGKrYeDjvIpKTR38UzmtHJOGW3Q==
   dependencies:
     "@types/react" "*"
 
@@ -2277,11 +2244,6 @@ aria-hidden@^1.1.3, aria-hidden@^1.2.4:
   dependencies:
     tslib "^2.0.0"
 
-arrify@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
-  integrity sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==
-
 assertion-error@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-2.0.1.tgz#f641a196b335690b1070bf00b6e7593fec190bf7"
@@ -2681,7 +2643,7 @@ compare-version@^0.1.2:
   resolved "https://registry.yarnpkg.com/compare-version/-/compare-version-0.1.2.tgz#0162ec2d9351f5ddd59a9202cba935366a725080"
   integrity sha512-pJDh5/4wrEnXX/VWRZvruAGHkzKdr46z11OlTPN+VrATlWWhSKewNCJ1futCO5C7eJB3nPMFZA1LeYtcFboZ2A==
 
-compute-scroll-into-view@^1.0.14, compute-scroll-into-view@^1.0.17:
+compute-scroll-into-view@^1.0.17:
   version "1.0.20"
   resolved "https://registry.yarnpkg.com/compute-scroll-into-view/-/compute-scroll-into-view-1.0.20.tgz#1768b5522d1172754f5d0c9b02de3af6be506a43"
   integrity sha512-UCB0ioiyj8CRjtrvaceBLqqhZCVP+1B8+NWQhmdsm0VXOJtobBCf1dBQmebCCo34qZmUwZfIH2MZLqNHazrfjg==
@@ -2739,14 +2701,6 @@ css-color-keywords@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/css-color-keywords/-/css-color-keywords-1.0.0.tgz#fea2616dc676b2962686b3af8dbdbe180b244e05"
   integrity sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU=
-
-css-in-js-utils@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz#3b472b398787291b47cfe3e44fecfdd9e914ba99"
-  integrity sha512-PJF0SpJT+WdbVVt0AOYp9C8GnuruRlL/UFW7932nLWmFLQTaWEzTBQEx7/hn4BuV+WON75iAViSUJLiU3PKbpA==
-  dependencies:
-    hyphenate-style-name "^1.0.2"
-    isobject "^3.0.1"
 
 css-to-react-native@^3.0.0:
   version "3.0.0"
@@ -2930,30 +2884,12 @@ dlv@^1.1.3:
   resolved "https://registry.yarnpkg.com/dlv/-/dlv-1.1.3.tgz#5c198a8a11453596e751494d49874bc7732f2e79"
   integrity sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==
 
-dom-helpers@^5.0.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.1.tgz#d9400536b2bf8225ad98fe052e029451ac40e902"
-  integrity sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==
-  dependencies:
-    "@babel/runtime" "^7.8.7"
-    csstype "^3.0.2"
-
 dot-prop@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-6.0.1.tgz#fc26b3cf142b9e59b74dbd39ed66ce620c681083"
   integrity sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==
   dependencies:
     is-obj "^2.0.0"
-
-downshift@^5.2.0:
-  version "5.4.7"
-  resolved "https://registry.yarnpkg.com/downshift/-/downshift-5.4.7.tgz#2ab7b0512cad33011ee6f29630f9a7bb74dff2b5"
-  integrity sha512-xaH0RNqwJ5pAsyk9qBmR9XJWmg1OOWMfrhzYv0NH2NjJxn77S3zBcfClw341UfhGyKg5v+qVqg/CQzvAgBNCXQ==
-  dependencies:
-    "@babel/runtime" "^7.10.2"
-    compute-scroll-into-view "^1.0.14"
-    prop-types "^15.7.2"
-    react-is "^16.13.1"
 
 downshift@^6.1.12:
   version "6.1.12"
@@ -3092,29 +3028,6 @@ esm@^3.2.25:
   version "3.2.25"
   resolved "https://registry.yarnpkg.com/esm/-/esm-3.2.25.tgz#342c18c29d56157688ba5ce31f8431fbb795cc10"
   integrity sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==
-
-evergreen-ui@^7.1.9:
-  version "7.1.9"
-  resolved "https://registry.yarnpkg.com/evergreen-ui/-/evergreen-ui-7.1.9.tgz#1d967fa62098c0bf5801d94260a725551bcc964b"
-  integrity sha512-/2ltUobNMDRfjteUwG6Xbb2N27DgaNCq4gOipPcmU6Z1w6xL3NLTGLKW28hqAcwvxHADr4ExkXMOP8Uu/szefg==
-  dependencies:
-    "@babel/runtime" "^7.1.2"
-    "@segment/react-tiny-virtual-list" "^2.2.1"
-    "@types/react-transition-group" "^4.4.0"
-    arrify "^1.0.1"
-    downshift "^5.2.0"
-    fuzzaldrin-plus "^0.6.0"
-    humanize-plus "^1.8.2"
-    lodash.debounce "^4.0.8"
-    lodash.differencewith "^4.5.0"
-    lodash.isempty "^4.4.0"
-    lodash.merge "^4.6.2"
-    lodash.omit "^4.5.0"
-    lodash.uniqby "^4.7.0"
-    prop-types "^15.6.2"
-    react-fast-compare "^3.2.0"
-    react-transition-group "^4.4.1"
-    ui-box "^5.4.1"
 
 expand-template@^2.0.3:
   version "2.0.3"
@@ -3330,11 +3243,6 @@ function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
-
-fuzzaldrin-plus@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/fuzzaldrin-plus/-/fuzzaldrin-plus-0.6.0.tgz#832f6489fbe876769459599c914a670ec22947ee"
-  integrity sha512-srIDThJHkdp3aPwJpR/HNzYZCRJwm07b/igxseoHSB7qR8e/gQp4F6lMGknE3TQI1Aq14TiFf/wzrHOp9LY/EA==
 
 galactus@^1.0.0:
   version "1.0.0"
@@ -3629,16 +3537,6 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
-humanize-plus@^1.8.2:
-  version "1.8.2"
-  resolved "https://registry.yarnpkg.com/humanize-plus/-/humanize-plus-1.8.2.tgz#a65b34459ad6367adbb3707a82a3c9f916167030"
-  integrity sha512-jaLeQyyzjjINGv7O9JJegjsaUcWjSj/1dcXvLEgU3pGdqCdP1PiC/uwr+saJXhTNBHZtmKnmpXyazgh+eceRxA==
-
-hyphenate-style-name@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.3.tgz#097bb7fa0b8f1a9cf0bd5c734cf95899981a9b48"
-  integrity sha512-EcuixamT82oplpoJ2XU4pDtKGWQ7b00CD9f1ug9IaQ3p1bkHMiKCZ9ut9QDI6qsa6cpUuB+A/I+zLtdNK4n2DQ==
-
 icon-gen@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/icon-gen/-/icon-gen-5.0.0.tgz#5658e99e4b710e31f4b8fb3473478716a08db268"
@@ -3697,13 +3595,6 @@ ini@~1.3.0:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
-
-inline-style-prefixer@^5.0.4:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/inline-style-prefixer/-/inline-style-prefixer-5.1.2.tgz#e5a5a3515e25600e016b71e39138971228486c33"
-  integrity sha512-PYUF+94gDfhy+LsQxM0g3d6Hge4l1pAqOSOiZuHWzMvQEGsbRQ/ck2WioLqrY2ZkHyPgVUXxn+hrkF7D6QUGbA==
-  dependencies:
-    css-in-js-utils "^2.0.0"
 
 interpret@^2.2.0:
   version "2.2.0"
@@ -3866,11 +3757,6 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
-
-isobject@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
-  integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
 jackspeak@^2.3.5:
   version "2.3.6"
@@ -4039,45 +3925,15 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-lodash.debounce@^4.0.8:
-  version "4.0.8"
-  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
-  integrity sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==
-
-lodash.differencewith@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.differencewith/-/lodash.differencewith-4.5.0.tgz#bafafbc918b55154e179176a00bb0aefaac854b7"
-  integrity sha512-/8JFjydAS+4bQuo3CpLMBv7WxGFyk7/etOAsrQUCu0a9QVDemxv0YQ0rFyeZvqlUD314SERfNlgnlqqHmaQ0Cg==
-
 lodash.get@^4.0.0:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==
 
-lodash.isempty@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.isempty/-/lodash.isempty-4.4.0.tgz#6f86cbedd8be4ec987be9aaf33c9684db1b31e7e"
-  integrity sha512-oKMuF3xEeqDltrGMfDxAPGIVMSSRv8tbRSODbrs4KGsRRLEhrW8N8Rd4DRgB2+621hY8A8XwwrTVhXWpxFvMzg==
-
 lodash.mapvalues@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz#1bafa5005de9dd6f4f26668c30ca37230cc9689c"
   integrity sha512-JPFqXFeZQ7BfS00H58kClY7SPVeHertPE0lNuCyZ26/XlN8TvakYD7b9bGyNmXbT/D3BbtPAAmq90gPWqLkxlQ==
-
-lodash.merge@^4.6.2:
-  version "4.6.2"
-  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
-  integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
-
-lodash.omit@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.omit/-/lodash.omit-4.5.0.tgz#6eb19ae5a1ee1dd9df0b969e66ce0b7fa30b5e60"
-  integrity sha512-XeqSp49hNGmlkj2EJlfrQFIzQ6lXdNro9sddtQzcJY8QaoC2GO0DT7xaIokHeyM+mIT0mPMlPvkYzg2xCuHdZg==
-
-lodash.uniqby@^4.7.0:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz#d99c07a669e9e6d24e1362dfe266c67616af1302"
-  integrity sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==
 
 lodash@^4.17.11, lodash@^4.17.13:
   version "4.17.20"
@@ -5316,15 +5172,6 @@ promise-retry@^2.0.1:
     err-code "^2.0.2"
     retry "^0.12.0"
 
-prop-types@^15.5.7, prop-types@^15.6.2:
-  version "15.8.1"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
-  integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
-  dependencies:
-    loose-envify "^1.4.0"
-    object-assign "^4.1.1"
-    react-is "^16.13.1"
-
 prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
@@ -5399,11 +5246,6 @@ react-dom@^18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
-react-fast-compare@^3.2.0:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.2.tgz#929a97a532304ce9fee4bcae44234f1ce2c21d49"
-  integrity sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==
-
 react-hotkeys-hook@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/react-hotkeys-hook/-/react-hotkeys-hook-4.5.0.tgz#807b389b15256daf6a813a1ec09e6698064fe97f"
@@ -5414,7 +5256,7 @@ react-hotkeys-hook@^4.6.1:
   resolved "https://registry.yarnpkg.com/react-hotkeys-hook/-/react-hotkeys-hook-4.6.1.tgz#db9066c07377a1c8be067a238ab16e328266345a"
   integrity sha512-XlZpbKUj9tkfgPgT9gA+1p7Ey6vFIZHttUjPqpTdyT5nqQ8mHL7elxvSbaC+dpSiHUSmr21Ya1mDxBZG3aje4Q==
 
-react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.1:
+react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -5520,16 +5362,6 @@ react-tracked@^1.7.11:
   dependencies:
     proxy-compare "2.6.0"
     use-context-selector "1.4.4"
-
-react-transition-group@^4.4.1:
-  version "4.4.5"
-  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.5.tgz#e53d4e3f3344da8521489fbef8f2581d42becdd1"
-  integrity sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==
-  dependencies:
-    "@babel/runtime" "^7.5.5"
-    dom-helpers "^5.0.1"
-    loose-envify "^1.4.0"
-    prop-types "^15.6.2"
 
 react@^18.2.0:
   version "18.2.0"
@@ -5970,16 +5802,7 @@ ssri@^9.0.0:
   dependencies:
     minipass "^3.1.1"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -6004,14 +5827,7 @@ string_decoder@^1.1.1:
   dependencies:
     safe-buffer "~5.2.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -6287,15 +6103,6 @@ typescript@^5.3.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.3.3.tgz#b3ce6ba258e72e6305ba66f5c9b452aaee3ffe37"
   integrity sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==
 
-ui-box@^5.4.1:
-  version "5.4.1"
-  resolved "https://registry.yarnpkg.com/ui-box/-/ui-box-5.4.1.tgz#34f497a143783a3513e850bd58379ac583e3f2fb"
-  integrity sha512-5p+b6kSh1q/bptvLANuAusyB/3fGIvnw8w6rSZNPHckQ8UdPfjIK4DvinmMXRKgdniOba22h8ypVqtkJ9zK/iQ==
-  dependencies:
-    "@emotion/hash" "^0.7.1"
-    inline-style-prefixer "^5.0.4"
-    prop-types "^15.7.2"
-
 undici-types@~5.26.4:
   version "5.26.5"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
@@ -6511,16 +6318,7 @@ workerpool@6.2.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
- remove all usages of evergreen-ui, then drop it

Long-standing effort to move towards esm, and unify the styles / components / css under a single hood. Evergreen was a great library, despite no longer being updated.


Closes #215 
Part of #214 