### PR TITLE
fix: use dark styles in markdown edit mode

### DIFF
--- a/src/views/edit/markdown-editor/MarkdownEditor.tsx
+++ b/src/views/edit/markdown-editor/MarkdownEditor.tsx
@@ -75,7 +75,7 @@ const MarkdownEditor = observer(
 
             <textarea
               placeholder="Write your markdown here..."
-              className="flex w-full flex-grow bg-white font-mono text-sm focus:outline-none"
+              className="flex w-full flex-grow bg-background font-mono text-sm focus:outline-none"
               value={markdownContent}
               onChange={handleMarkdownChange}
               spellCheck="true"

--- a/src/views/edit/markdown-editor/MarkdownFrontMatter.tsx
+++ b/src/views/edit/markdown-editor/MarkdownFrontMatter.tsx
@@ -22,7 +22,7 @@ export const MarkdownFrontMatter = observer(
     }
 
     return (
-      <div className="mb-6 rounded-sm border border-gray-200 bg-gray-50 p-4">
+      <div className="mb-6 rounded-sm border border-border bg-muted p-4">
         <h2 className="mb-2 font-medium">Document Metadata</h2>
         <div className="grid grid-cols-2 gap-2">
           <div>


### PR DESCRIPTION
- also use dark-aware styles in markdown editor mode

<img width="747" alt="Screenshot 2025-06-19 at 12 08 35 PM" src="https://github.com/user-attachments/assets/7dcd8804-e46c-4a93-a658-7f9b15ad6e6c" />
