### PR TITLE
feat: constraint width; preferences styling

### DIFF
--- a/docs/editor/styling.md
+++ b/docs/editor/styling.md
@@ -1,0 +1,73 @@
+# Editor Styling
+
+The editor's styling is primarily managed through Tailwind CSS classes applied to Plate.js components. This document provides a high-level overview for developers familiar with React and Tailwind.
+
+## Key Files & Concepts
+
+- **`src/views/edit/PlateContainer.tsx`**: This is the central configuration for the Plate editor. It uses `createPlugins` to initialize all editor features (elements, marks, plugins). The `components` object within this configuration is crucial, as it maps Plate's abstract element types (e.g., `ELEMENT_H1`, `MARK_BOLD`) to specific React components.
+
+- **`src/views/edit/editor/elements/`**: This directory contains the custom React components that render the visual representation of each editor element. Each component is responsible for its own styling via Tailwind classes.
+
+- **Styling Libraries**:
+  - **`class-variance-authority` (`cva`)**: Used in components like `Heading.tsx` to create different style variants based on props (e.g., heading level).
+  - **`@udecode/cn` (`withCn`, `withVariants`, `cn`)**: A set of utilities for applying Tailwind classes to Plate components. `withCn` applies a static set of classes, while `withVariants` combines a component with `cva` variants.
+
+## Styling Patterns
+
+The common pattern is to wrap a `PlateElement` and apply styles using Tailwind classes.
+
+### Example 1: `Heading.tsx`
+
+```tsx
+// src/views/edit/editor/elements/Heading.tsx
+
+const headingVariants = cva("", {
+  variants: {
+    variant: {
+      h1: "font-heading text-2xl font-medium",
+      h2: "font-heading-2 text-xl font-medium",
+      // ...
+    },
+  },
+});
+
+const HeadingElementVariants = withVariants(PlateElement, headingVariants, [
+  "variant",
+]);
+```
+
+This demonstrates the use of `cva` and `withVariants` to create styled components based on props. The `variant` prop (`h1`, `h2`, etc.) is passed from `PlateContainer.tsx`.
+
+### Example 2: `Blockquote.tsx`
+
+```tsx
+// src/views/edit/editor/elements/Blockquote.tsx
+
+export const BlockquoteElement = withRef<typeof PlateElement>(
+  ({ className, children, ...props }, ref) => {
+    return (
+      <PlateElement
+        ref={ref}
+        asChild
+        className={cn("border-l-4 pl-6 italic", className)}
+        {...props}
+      >
+        <blockquote>{children}</blockquote>
+      </PlateElement>
+    );
+  },
+);
+```
+
+This shows two important patterns:
+
+1.  The `cn` utility is used to merge base classes with any classes passed via props.
+2.  The `asChild` prop instructs `PlateElement` to pass its props (including the merged `className`) to its immediate child (`<blockquote>`) instead of rendering its own `div`. This results in cleaner HTML and is a common pattern when using component libraries with Tailwind.
+
+## Summary
+
+To modify or add styles to editor elements, a developer should:
+
+1.  Locate the corresponding element component in `src/views/edit/editor/elements/`.
+2.  Modify the Tailwind CSS classes within that file.
+3.  For new elements, create a new component, and map it to a Plate element type in `src/views/edit/PlateContainer.tsx`.

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -14,7 +14,7 @@ const buttonVariants = cva(
         ghost:
           "hover:border-accent-muted hover:text-foreground-strong border border-muted text-muted-foreground",
         destructive:
-          "hover:text-destructive-foreground border border-destructive/60 shadow-sm hover:bg-destructive/80 focus:outline-none focus:ring-2 focus:ring-destructive/60",
+          "hover:text-destructive-foreground border border-destructive shadow-sm hover:bg-destructive/80 focus:outline-none focus:ring-2 focus:ring-destructive/60",
         secondary:
           "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
         link: "text-primary underline-offset-4 hover:underline",

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -36,6 +36,7 @@ const dialogVariants = cva(defaultStyles, {
   variants: {
     variant: {
       default: "max-h-[90vh] w-full max-w-lg grid gap-4 overflow-y-auto p-6",
+      fullish: "max-h-[90vh] w-[90%] grid gap-4 overflow-y-auto p-6 rounded-sm",
       max: "h-[calc(90vh-var(--titlebar-height))] w-full p-6 flex items-center justify-center",
     },
     animate: {

--- a/src/container.tsx
+++ b/src/container.tsx
@@ -6,7 +6,7 @@ import { Alert } from "./components";
 import ErrorBoundary from "./error";
 import { ApplicationContext, useAppLoader } from "./hooks/useApplicationLoader";
 import Titlebar from "./titlebar/macos";
-import { FontWatcher } from "./views/FontWatcher";
+import { StyleWatcher } from "./views/StyleWatcher";
 import { ThemeWatcher } from "./views/ThemeWatcher";
 import DocumentCreator from "./views/create";
 import Documents from "./views/documents";
@@ -68,7 +68,7 @@ export default observer(function Container() {
   return (
     <ApplicationContext.Provider value={applicationStore}>
       <ThemeWatcher preferences={applicationStore.preferences} />
-      <FontWatcher preferences={applicationStore.preferences} />
+      <StyleWatcher preferences={applicationStore.preferences} />
       <Layout>
         <Preferences
           isOpen={applicationStore.isPreferencesOpen}

--- a/src/electron/settings.ts
+++ b/src/electron/settings.ts
@@ -17,6 +17,10 @@ export interface IPreferences {
     systemBody?: string;
     systemHeading?: string;
   };
+  maxWidth: {
+    prose?: string;
+    code?: string;
+  };
 }
 
 const defaults: IPreferences = {
@@ -38,6 +42,10 @@ const defaults: IPreferences = {
       '"Mona Sans", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif',
     systemHeading:
       '"Hubot Sans", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif',
+  },
+  maxWidth: {
+    prose: "768px",
+    code: undefined,
   },
 };
 

--- a/src/hooks/stores/preferences.ts
+++ b/src/hooks/stores/preferences.ts
@@ -24,6 +24,10 @@ export class Preferences implements IPreferences {
     systemBody?: string;
     systemHeading?: string;
   };
+  maxWidth!: {
+    prose?: string;
+    code?: string;
+  };
 
   constructor(prefs: IPreferences, client: IClient["preferences"]) {
     Object.assign(this, prefs);
@@ -36,6 +40,7 @@ export class Preferences implements IPreferences {
       onboarding: observable,
       darkMode: observable,
       fonts: observable,
+      maxWidth: observable,
     });
 
     this._lastSynced = { ...prefs };
@@ -53,6 +58,7 @@ export class Preferences implements IPreferences {
         darkMode: this.darkMode,
         // todo: add test for fonts syncing with settings store
         fonts: toJS(this.fonts),
+        maxWidth: toJS(this.maxWidth),
       }),
       (prefs: IPreferences) => {
         let toWrite: Partial<IPreferences> = {};

--- a/src/index.css
+++ b/src/index.css
@@ -6,6 +6,9 @@
 /* This section initially added as recommended copypasta https://platejs.org/docs/components/installation/manual */
 @layer base {
   :root {
+    --max-w-prose: 768px;
+    --max-w-code: var(--max-w-prose);
+
     --font-sans: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
       "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
     --font-serif: ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
@@ -175,6 +178,20 @@
     --tag-secondary-foreground-hint: hsl(210 40% 98%);
 
     --ring: 217.2 32.6% 17.5%;
+  }
+}
+
+@layer utilities {
+  .min-w-prose {
+    min-width: var(--max-w-prose);
+  }
+
+  .max-w-prose {
+    max-width: var(--max-w-prose);
+  }
+
+  .max-w-code {
+    max-width: var(--max-w-code);
   }
 }
 

--- a/src/views/StyleWatcher.tsx
+++ b/src/views/StyleWatcher.tsx
@@ -7,14 +7,18 @@ interface Props {
   preferences: Preferences;
 }
 
-export const FontWatcher: React.FC<Props> = observer(({ preferences }) => {
+/**
+ * Watches preference changes and updates CSS custom properties on the document root.
+ * Handles fonts and max-width styling preferences.
+ */
+export const StyleWatcher: React.FC<Props> = observer(({ preferences }) => {
   React.useEffect(() => {
-    return reaction(
+    // Watch font preferences
+    const fontDisposer = reaction(
       () => toJS(preferences.fonts),
       (fonts) => {
         const root = document.documentElement;
 
-        // Apply font preferences to CSS variables
         if (fonts.heading) {
           root.style.setProperty("--font-heading", fonts.heading);
         }
@@ -44,9 +48,36 @@ export const FontWatcher: React.FC<Props> = observer(({ preferences }) => {
         }
       },
       {
-        fireImmediately: true, // Fire immediately to set the initial state
+        fireImmediately: true,
       },
     );
+
+    // Watch max-width preferences
+    const maxWidthDisposer = reaction(
+      () => toJS(preferences.maxWidth),
+      (maxWidth) => {
+        const root = document.documentElement;
+
+        if (maxWidth.prose) {
+          root.style.setProperty("--max-w-prose", maxWidth.prose);
+        }
+
+        if (maxWidth.code) {
+          root.style.setProperty("--max-w-code", maxWidth.code);
+        } else {
+          root.style.setProperty("--max-w-code", "var(--max-w-prose)");
+        }
+      },
+      {
+        fireImmediately: true,
+      },
+    );
+
+    // Cleanup both reactions
+    return () => {
+      fontDisposer();
+      maxWidthDisposer();
+    };
   }, []);
 
   return null;

--- a/src/views/documents/Input.tsx
+++ b/src/views/documents/Input.tsx
@@ -5,15 +5,18 @@ import { cn } from "@udecode/cn";
 export interface InputProps
   extends React.InputHTMLAttributes<HTMLInputElement> {}
 
+const baseClasses = cn(
+  "flex w-full rounded-sm border border-input bg-transparent text-xs p-1 shadow-sm transition-colors",
+  "file:border-0 file:bg-transparent file:text-sm file:font-medium",
+  "placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+);
+
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className, type, ...props }, ref) => {
     return (
       <input
         type={type}
-        className={cn(
-          "flex w-full rounded-md border border-input bg-transparent text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
-          className,
-        )}
+        className={cn(baseClasses, className)}
         ref={ref}
         {...props}
       />

--- a/src/views/edit/editor/elements/Blockquote.tsx
+++ b/src/views/edit/editor/elements/Blockquote.tsx
@@ -9,7 +9,7 @@ export const BlockquoteElement = withRef<typeof PlateElement>(
         ref={ref}
         asChild
         className={cn(
-          "my-6 border-l-4 pl-6 italic text-muted-foreground",
+          "my-6 max-w-prose border-l-4 pl-6 italic text-muted-foreground",
           className,
         )}
         {...props}

--- a/src/views/edit/editor/elements/CodeBlock.tsx
+++ b/src/views/edit/editor/elements/CodeBlock.tsx
@@ -70,7 +70,11 @@ export const CodeBlockElement = withRef<typeof PlateElement>(
 
     return (
       <PlateElement
-        className={cn("relative my-8 bg-muted", state.className, className)}
+        className={cn(
+          "max-w-code relative my-8 bg-muted",
+          state.className,
+          className,
+        )}
         ref={ref}
         {...props}
       >

--- a/src/views/edit/editor/elements/Heading.tsx
+++ b/src/views/edit/editor/elements/Heading.tsx
@@ -2,23 +2,26 @@ import { withRef, withVariants } from "@udecode/cn";
 import { PlateElement } from "@udecode/plate-common";
 import { cva } from "class-variance-authority";
 import React from "react";
-3;
-const headingVariants = cva("", {
-  variants: {
-    variant: {
-      h1: "mb-[0.5em] mt-[1.6em] font-heading text-2xl font-medium tracking-tight",
-      h2: "mb-[0.5em] mt-[1.4em] font-heading-2 text-xl font-medium tracking-tight",
-      h3: "mb-[0.5em] mt-[1em] font-heading-3 text-lg font-medium tracking-tight",
-      h4: "mt-[0.75em] font-heading-3 text-lg font-medium tracking-tight",
-      h5: "mt-[0.75em] text-lg font-heading-3 font-medium tracking-tight",
-      h6: "mt-[0.75em] text-base font-heading-3 font-medium tracking-tight",
-    },
-    isFirstBlock: {
-      true: "mt-0",
-      false: "",
+
+const headingVariants = cva(
+  "text-left tracking-tight min-w-prose max-w-prose font-medium",
+  {
+    variants: {
+      variant: {
+        h1: "mb-[0.5em] mt-[1.6em] font-heading text-2xl",
+        h2: "mb-[0.5em] mt-[1.4em] font-heading-2 text-xl",
+        h3: "mb-[0.5em] mt-[1em] font-heading-3 text-lg",
+        h4: "mt-[0.75em] font-heading-3 text-lg",
+        h5: "mt-[0.75em] text-lg font-heading-3",
+        h6: "mt-[0.75em] text-base font-heading-3",
+      },
+      isFirstBlock: {
+        true: "mt-0",
+        false: "",
+      },
     },
   },
-});
+);
 
 const HeadingElementVariants = withVariants(PlateElement, headingVariants, [
   "isFirstBlock",

--- a/src/views/edit/editor/elements/List.tsx
+++ b/src/views/edit/editor/elements/List.tsx
@@ -6,7 +6,7 @@ import { cva } from "class-variance-authority";
 
 const listVariants = cva(
   cn(
-    "m-0 ps-6 mb-6",
+    "m-0 ps-6 mb-6 max-w-prose min-w-prose",
     // Second and Third level lists structure like:
     // <ul><li> Stuff.... <ul><li> Level 2 stuff...</li></ul></li></ul>
     // So remove mb from nested (parent li already has), and

--- a/src/views/edit/editor/elements/Paragraph.tsx
+++ b/src/views/edit/editor/elements/Paragraph.tsx
@@ -1,4 +1,7 @@
 import { withCn } from "@udecode/cn";
 import { PlateElement } from "@udecode/plate-common";
 
-export const ParagraphElement = withCn(PlateElement, "mx-0 mb-4 mt-px px-0");
+export const ParagraphElement = withCn(
+  PlateElement,
+  "mb-4 mt-px px-0 max-w-prose min-w-prose",
+);

--- a/src/views/edit/editor/features/images/ImageElement.tsx
+++ b/src/views/edit/editor/features/images/ImageElement.tsx
@@ -17,7 +17,7 @@ export const ImageElement = ({
 
   return (
     <MediaPopover pluginKey={ELEMENT_IMAGE}>
-      <PlateElement className={cn("flex justify-center", className)} {...props}>
+      <PlateElement className={cn("flex justify-start", className)} {...props}>
         <ImageDisplay
           {...media}
           className="my-8 max-h-96 max-w-full cursor-pointer object-scale-down"

--- a/src/views/edit/editor/features/images/MediaWrapper.tsx
+++ b/src/views/edit/editor/features/images/MediaWrapper.tsx
@@ -121,7 +121,7 @@ export const MediaWrapper = ({
           url={url}
           focused={focused}
           selected={selected}
-          className={cn("mx-auto block max-h-80 max-w-[80%]", className)}
+          className={cn("block max-h-80 max-w-[80%]", className)}
           onClick={(e) => onClick?.(e)}
           onError={handleError}
           onLoad={onLoad}

--- a/src/views/preferences/index.tsx
+++ b/src/views/preferences/index.tsx
@@ -1,6 +1,7 @@
 import { observable } from "mobx";
 import { observer } from "mobx-react-lite";
 import React, { PropsWithChildren } from "react";
+import { InputProps } from "react-day-picker";
 import { toast } from "sonner";
 import { Label, Select } from "../../components";
 import { Button } from "../../components/Button";
@@ -19,6 +20,7 @@ import {
   SKIPPABLE_FILES,
   SKIPPABLE_PREFIXES,
 } from "../../preload/client/types";
+import { Input } from "../documents/Input";
 
 interface Props {
   isOpen: boolean;
@@ -99,9 +101,9 @@ const PreferencesPane = observer((props: Props) => {
 
   return (
     <Dialog open={props.isOpen} onOpenChange={props.onClose}>
-      <DialogContent>
+      <DialogContent variant="fullish">
         <DialogHeader>
-          <DialogTitle>Settings</DialogTitle>
+          <DialogTitle className="sticky">Settings</DialogTitle>
           <Separator />
           <DialogDescription asChild>
             <div>
@@ -111,17 +113,22 @@ const PreferencesPane = observer((props: Props) => {
                   sub="Customize the look and feel of Chronicles"
                 />
 
-                <dl className="grid grid-cols-[auto_1fr] gap-x-2 gap-y-1 text-sm">
-                  <dt className="text-foreground-strong font-medium">Theme</dt>
-                  <dd className="mb-2 text-xs text-muted-foreground">
+                <div className="my-4 flex justify-between">
+                  <div className="text-foreground-strong mb-2 font-medium">
+                    Theme
+                  </div>
+                  <div className="mb-2 text-xs text-muted-foreground">
                     <code>Default</code>
-                  </dd>
-                  <dt className="text-foreground-strong font-medium">
+                  </div>
+                </div>
+
+                <div className="my-4 flex justify-between">
+                  <div className="text-foreground-strong mb-2 font-medium">
                     <Label.Base htmlFor=":r2g:-form-item">
                       Appearance
                     </Label.Base>
-                  </dt>
-                  <dd className="mb-2 text-xs text-muted-foreground">
+                  </div>
+                  <div className="mb-2 text-xs text-muted-foreground">
                     <Select.Base
                       value={preferences.darkMode}
                       onValueChange={(selected) =>
@@ -140,8 +147,8 @@ const PreferencesPane = observer((props: Props) => {
                         <Select.Item value="system">System</Select.Item>
                       </Select.Content>
                     </Select.Base>
-                  </dd>
-                </dl>
+                  </div>
+                </div>
               </Section>
               <Section>
                 <SectionTitle
@@ -150,89 +157,96 @@ const PreferencesPane = observer((props: Props) => {
                 />
 
                 <div className="space-y-6">
-                  <div>
-                    <h4 className="mb-3 text-base font-medium">Base Fonts</h4>
-                    <div className="space-y-4">
-                      <FontSelector
-                        label="Heading"
-                        description="Hubot Sans (bundled) - Main headings and titles"
-                        value={
-                          preferences.fonts?.heading || "Hubot Sans (bundled)"
-                        }
-                        onChange={(font) => {
-                          preferences.fonts.heading = font;
-                        }}
-                      />
-                      <FontSelector
-                        label="Body"
-                        description="Mona Sans (bundled) - Interface and content text"
-                        value={preferences.fonts?.body || "Mona Sans (bundled)"}
-                        onChange={(font) => {
-                          preferences.fonts.body = font;
-                        }}
-                      />
-                      <FontSelector
-                        label="Mono"
-                        description="IBM Plex Mono (bundled) - Code blocks and dates"
-                        value={
-                          preferences.fonts?.mono || "IBM Plex Mono (bundled)"
-                        }
-                        onChange={(font) => {
-                          preferences.fonts.mono = font;
-                        }}
-                      />
-                      <FontSelector
-                        label="System Body"
-                        description="Mona Sans (bundled) - Interface elements, sidebar, preferences"
-                        value={
-                          preferences.fonts?.systemBody || "Mona Sans (bundled)"
-                        }
-                        onChange={(font) => {
-                          preferences.fonts.systemBody = font;
-                        }}
-                      />
-                      <FontSelector
-                        label="System Heading"
-                        description="Hubot Sans (bundled) - Interface section titles and headers"
-                        value={
-                          preferences.fonts?.systemHeading ||
-                          "Hubot Sans (bundled)"
-                        }
-                        onChange={(font) => {
-                          preferences.fonts.systemHeading = font;
-                        }}
-                      />
-                    </div>
-                  </div>
+                  <FontSelector
+                    label="Heading"
+                    description="Hubot Sans (bundled) - Main headings and titles"
+                    value={preferences.fonts?.heading || "Hubot Sans (bundled)"}
+                    onChange={(font) => {
+                      preferences.fonts.heading = font;
+                    }}
+                  />
 
+                  <FontSelector
+                    label="Heading 2"
+                    value={preferences.fonts?.heading2 || "Default (Heading)"}
+                    onChange={(font) => {
+                      preferences.fonts.heading2 =
+                        font === "Default (Heading)" ? undefined : font;
+                    }}
+                    isSpecific={true}
+                  />
+                  <FontSelector
+                    label="Heading 3"
+                    value={preferences.fonts?.heading3 || "Default (Heading)"}
+                    onChange={(font) => {
+                      preferences.fonts.heading3 =
+                        font === "Default (Heading)" ? undefined : font;
+                    }}
+                    isSpecific={true}
+                  />
+                  <FontSelector
+                    label="Body"
+                    description="Interface and content text"
+                    value={preferences.fonts?.body || "Mona Sans (bundled)"}
+                    onChange={(font) => {
+                      preferences.fonts.body = font;
+                    }}
+                  />
+                  <FontSelector
+                    label="Mono"
+                    description="Code blocks and dates"
+                    value={preferences.fonts?.mono || "IBM Plex Mono (bundled)"}
+                    onChange={(font) => {
+                      preferences.fonts.mono = font;
+                    }}
+                  />
+                  <FontSelector
+                    label="System Body"
+                    description="Interface elements, sidebar, preferences"
+                    value={
+                      preferences.fonts?.systemBody || "Mona Sans (bundled)"
+                    }
+                    onChange={(font) => {
+                      preferences.fonts.systemBody = font;
+                    }}
+                  />
+                  <FontSelector
+                    label="System Heading"
+                    description="Interface section titles and headers"
+                    value={
+                      preferences.fonts?.systemHeading || "Hubot Sans (bundled)"
+                    }
+                    onChange={(font) => {
+                      preferences.fonts.systemHeading = font;
+                    }}
+                  />
+                </div>
+              </Section>
+              <Section>
+                <SectionTitle
+                  title="Max Width"
+                  sub="Customize the max-width of different parts of the application"
+                />
+
+                <div className="space-y-6">
                   <div>
-                    <h4 className="mb-3 text-base font-medium">
-                      Specific Elements
-                    </h4>
                     <div className="space-y-4">
-                      <FontSelector
-                        label="Heading 2"
-                        description="Defaults to: Heading"
-                        value={
-                          preferences.fonts?.heading2 || "Default (Heading)"
-                        }
-                        onChange={(font) => {
-                          preferences.fonts.heading2 =
-                            font === "Default (Heading)" ? undefined : font;
+                      <WidthSelector
+                        label="Prose"
+                        description="Max-width for text content"
+                        value={preferences.maxWidth?.prose || ""}
+                        onChange={(e) => {
+                          preferences.maxWidth.prose = e.target.value;
                         }}
-                        isSpecific={true}
                       />
-                      <FontSelector
-                        label="Heading 3"
-                        description="Defaults to: Heading"
-                        value={
-                          preferences.fonts?.heading3 || "Default (Heading)"
-                        }
-                        onChange={(font) => {
-                          preferences.fonts.heading3 =
-                            font === "Default (Heading)" ? undefined : font;
+                      <WidthSelector
+                        label="Code"
+                        description="Max-width for code blocks"
+                        value={preferences.maxWidth?.code || ""}
+                        placeholder="Defaults to Prose width ^"
+                        onChange={(e) => {
+                          preferences.maxWidth.code = e.target.value;
                         }}
-                        isSpecific={true}
                       />
                     </div>
                   </div>
@@ -266,7 +280,7 @@ const PreferencesPane = observer((props: Props) => {
                   </dd>
                 </dl>
                 {/* todo: https://stackoverflow.com/questions/8579055/how-do-i-move-files-in-node-js/29105404#29105404 */}
-                <div className="mt-4 flex justify-end">
+                <div className="mt-4 flex">
                   <Button
                     variant="ghost"
                     size="sm"
@@ -299,7 +313,7 @@ const PreferencesPane = observer((props: Props) => {
                   </p>
                 </details>
 
-                <div className="my-6 flex flex-col space-y-2">
+                <div className="my-6 flex max-w-[500px] flex-col space-y-2">
                   <Label.Base
                     className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
                     htmlFor=":r2g:-form-item"
@@ -312,14 +326,14 @@ const PreferencesPane = observer((props: Props) => {
                   >
                     Whether to use the Notion specific parser, which checks for
                     ids in titles and pseudo-front matter in content.
-                  </p>{" "}
+                  </p>
                   <Select.Base
                     value={store.sourceType}
                     onValueChange={(selected) =>
                       (store.sourceType = selected as SourceType)
                     }
                   >
-                    <Select.Trigger>
+                    <Select.Trigger style={{ width: "200px" }}>
                       <Select.Value placeholder="Choose import type" />
                     </Select.Trigger>
                     <Select.Content>
@@ -330,7 +344,7 @@ const PreferencesPane = observer((props: Props) => {
                     </Select.Content>
                   </Select.Base>
                 </div>
-                <div className="mt-4 flex justify-end">
+                <div className="mt-4 flex">
                   {/* todo: https://stackoverflow.com/questions/8579055/how-do-i-move-files-in-node-js/29105404#29105404 */}
                   <Button
                     variant="ghost"
@@ -348,7 +362,7 @@ const PreferencesPane = observer((props: Props) => {
                   title="Clear import table"
                   sub="Clearing import tables and syncing cache"
                 />
-                <p className="mb-2">
+                <p className="mb-2 max-w-[500px]">
                   <strong>(Advanced)</strong> Re-running import from same
                   location will skip previously imported files. To fully re-run
                   the import, you can clear the import tables by clicking below,
@@ -356,13 +370,13 @@ const PreferencesPane = observer((props: Props) => {
                   imported files are removed (<strong>manually, by you</strong>)
                   from root directory.
                 </p>
-                <p className="mb-2">
+                <p className="mb-2 max-w-[500px]">
                   Note that ids are generated and tracked in the import table
                   prior to creating the files, so these can be used to
                   (manually) link imported files to their location in
                   Chronicles.
                 </p>
-                <div className="mt-4 flex justify-end">
+                <div className="mt-4 flex">
                   <Button
                     variant="destructive"
                     onClick={clearImportTable}
@@ -377,14 +391,14 @@ const PreferencesPane = observer((props: Props) => {
                   title="Sync (Rebuild cache)"
                   sub="Rebuild the cache from the filesystem"
                 />
-                <p className="mb-2">
+                <p className="mb-2 max-w-[500px]">
                   Chronicles builds an index of all documents and journals
                   (folders) in <code>notesDir</code> to power its search and
                   general operation. When the cache is out of sync with the
                   filesystem, this can cause issues such as missing documents,
                   tags, or journals.
                 </p>
-                <p className="mb-2">
+                <p className="mb-2 max-w-[500px]">
                   "Syncing" the cache will rebuild the index from the
                   filesystem, ensuring that all documents, journals, and tags
                   are correctly indexed. This should be done anytime you make
@@ -392,11 +406,11 @@ const PreferencesPane = observer((props: Props) => {
                   another device (if the <code>notesDir</code> is synced via a
                   cloud service).
                 </p>
-                <p className="mb-2">
+                <p className="mb-2 max-w-[500px]">
                   The current Chronicles cache is located at{" "}
                   <code>{preferences.databaseUrl}</code>
                 </p>
-                <div className="mt-4 flex justify-end">
+                <div className="mt-4 flex">
                   <Button
                     variant="ghost"
                     loading={store.loading}
@@ -488,7 +502,7 @@ function FontSelector({
   isSpecific = false,
 }: {
   label: string;
-  description: string;
+  description?: string;
   value: string;
   onChange: (font: string) => void;
   isSpecific?: boolean;
@@ -508,7 +522,7 @@ function FontSelector({
   };
 
   return (
-    <div>
+    <div className="flex justify-between">
       <div className="mb-2">
         <Label.Base className="text-sm font-medium">{label}</Label.Base>
         <p className="text-xs text-muted-foreground">{description}</p>
@@ -533,6 +547,25 @@ function FontSelector({
           ))}
         </Select.Content>
       </Select.Base>
+    </div>
+  );
+}
+
+function WidthSelector({
+  label,
+  description,
+  ...rest
+}: {
+  label: string;
+  description: string;
+} & InputProps) {
+  return (
+    <div className="flex items-start justify-between">
+      <div className="mb-2">
+        <Label.Base className="text-sm font-medium">{label}</Label.Base>
+        <p className="text-xs text-muted-foreground">{description}</p>
+      </div>
+      <Input className="max-w-[250px]" {...rest} />
     </div>
   );
 }


### PR DESCRIPTION
- add a width constraint (custom max-w-prose) applied to text content; left-align as compromise
- make width configurable and add special handling for code blocks
- re-style preferences pane slightly

Largely based on personal preference around smaller text width; I generally prefer centered content to left-aligned, but it got a bit awkward with front-matter and left-aligned was a good-enough compromise for now. Ideally could make that configurable; content width is configurable, I assume code-block would be most likely to change first, so added additional width configuration for it. IMHO would be nice to make it configurable for total width and scroll vs wrapping. Code block theming is something I want the most, style wise, next. 

<img width="1212" height="620" alt="Screenshot 2025-11-25 at 9 30 31 PM" src="https://github.com/user-attachments/assets/770dd1bb-b6a1-4d13-8f3d-eaab17f14042" />


In addition to new config options, widened config pane because there was some weird overflow, and tweaked styling of drop downs, shrunk text blobs, and tried to tidy it all up. Would love to take it further but don't have the design chops to do it efficiently. 

<img width="753" height="492" alt="full width and re-arranged preferences" src="https://github.com/user-attachments/assets/df49b3a9-fb88-4196-bf4b-3c250f8901e8" />


Closes #386