### PR TITLE
fix: persist createdAt changes when updating document date

### DIFF
--- a/src/views/edit/EditableDocument.ts
+++ b/src/views/edit/EditableDocument.ts
@@ -172,6 +172,7 @@ export class EditableDocument {
       try {
         this.updatedAt = this.frontMatter.updatedAt = new Date().toISOString();
         this.frontMatter.title = this.title;
+        this.frontMatter.createdAt = this.createdAt;
         this.frontMatter.tags = this.tags;
 
         // todo: if we stay on this route, just make a separate saveFrontMatter method...


### PR DESCRIPTION
When a user changed a document's date via the date picker, the change wasn't being persisted. The issue was in EditableDocument.save() - it was updating frontMatter.title and frontMatter.tags before saving, but was missing the same update for frontMatter.createdAt.

This meant that even though the MobX observable document.createdAt was updated and triggered the auto-save reaction, the old createdAt value was being sent to the backend because it wasn't copied to frontMatter.

Fixes #391