### PR TITLE
feat: auto-complete tags

### DIFF
--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -7,4 +7,4 @@ export * as Label from "./Label";
 export * as Popover from "./Popover";
 export * as Select from "./Select";
 export * as Sidesheet from "./Sidesheet";
-export * as TagInput from "./TagInput";
+export * as TagInput from "./tag-input/TagInput";

--- a/src/components/tag-input/TagStore.test.ts
+++ b/src/components/tag-input/TagStore.test.ts
@@ -1,0 +1,131 @@
+import { runInAction } from "mobx";
+import assert from "node:assert";
+import { describe, test } from "node:test";
+import { TagStore } from "./TagStore";
+
+describe("TagStore", () => {
+  let store: TagStore;
+  const initialOptions = [
+    { value: "apple", label: "Fruit" },
+    { value: "banana", label: "Fruit" },
+    { value: "orange", label: "Fruit" },
+    { value: "carrot", label: "Vegetable" },
+  ];
+
+  const selectedOptions: string[] = [];
+
+  test("query filters options correctly", () => {
+    store = new TagStore(initialOptions, false, selectedOptions, 0);
+
+    runInAction(() => {
+      store.query = "app";
+    });
+    assert.strictEqual(
+      store.filteredOptions.length,
+      1,
+      "Should filter to 1 option for 'app'",
+    );
+    assert.strictEqual(
+      store.filteredOptions[0].value,
+      "apple",
+      "Should match 'apple'",
+    );
+
+    // Test no matching options
+    runInAction(() => {
+      store.query = "xyz";
+    });
+    assert.strictEqual(
+      store.filteredOptions.length,
+      0,
+      "Should filter to 0 options for 'xyz'",
+    );
+  });
+
+  test("arrow keys change focusedIdx and focusedOption", () => {
+    store = new TagStore(initialOptions, false, selectedOptions, 0);
+    runInAction(() => {
+      store.query = "a"; // Filter to "apple", "banana", "orange", "carrot"
+      store.isOpen = true;
+    });
+
+    assert.strictEqual(
+      store.focusedIdx,
+      0,
+      "Focused index should be 0 initially",
+    );
+    assert.strictEqual(
+      store.focusedOption?.value,
+      "apple",
+      "Focused option should be 'apple'",
+    );
+
+    // Arrow down
+    store.handleArrowDown();
+    assert.strictEqual(
+      store.focusedIdx,
+      1,
+      "Focused index should be 1 after arrow down",
+    );
+    assert.strictEqual(
+      store.focusedOption?.value,
+      "banana",
+      "Focused option should be 'banana'",
+    );
+
+    // Arrow up
+    store.handleArrowUp();
+    assert.strictEqual(
+      store.focusedIdx,
+      0,
+      "Focused index should be 0 after arrow up",
+    );
+    assert.strictEqual(
+      store.focusedOption?.value,
+      "apple",
+      "Focused option should be 'apple'",
+    );
+
+    // Loop around with arrow up
+    store.handleArrowUp(); // Should go to the last item
+    assert.strictEqual(
+      store.focusedIdx,
+      0,
+      "Focused index should stay on first time after arrow up from 0",
+    );
+
+    assert.strictEqual(
+      store.focusedOption?.value,
+      "apple",
+      "Focused option should be 'apple'",
+    );
+  });
+
+  test("FocusedIdx resets when query or isOpen changes", () => {
+    runInAction(() => {
+      store.query = "a";
+      store.isOpen = true;
+    });
+
+    store.handleArrowDown();
+    assert.strictEqual(store.focusedIdx, 1, "focusedIdx should be 1");
+
+    runInAction(() => {
+      store.query = "ba"; // Change query
+    });
+    assert.strictEqual(
+      store.focusedIdx,
+      0,
+      "focusedIdx should reset to 0 after query change",
+    );
+
+    runInAction(() => {
+      store.isOpen = false; // Close dropdown
+    });
+    assert.strictEqual(
+      store.focusedIdx,
+      null,
+      "focusedIdx should reset to null when dropdown closes",
+    );
+  });
+});

--- a/src/components/tag-input/TagStore.ts
+++ b/src/components/tag-input/TagStore.ts
@@ -1,0 +1,128 @@
+import { action, computed, makeObservable, observable, reaction } from "mobx";
+
+interface Option {
+  value: string;
+  label?: string;
+}
+
+// Abstracted view model logic from TagInput; mix of this and the component
+// logic can be improved
+export class TagStore {
+  query: string;
+  delayedQuery: string;
+  focusedIdx: number | null;
+  options: Option[];
+  tokens: string[];
+  openOnEmptyFocus?: boolean;
+
+  // todo: Needing this and isDropdownOpen smells; its primarily to support
+  // force opening / closing the menu; but in general could be improved
+  isOpen: boolean;
+  get isDropdownOpen(): boolean {
+    return (
+      (this.isOpen && this.filteredOptions.length > 0) ||
+      (this.isOpen && !!this.openOnEmptyFocus && this.query === "")
+    );
+  }
+
+  constructor(
+    options: Option[],
+    openOnEmptyFocus?: boolean,
+    tokens: string[] = [],
+    delay: number = 200,
+  ) {
+    // Accept tokens in constructor
+    this.query = "";
+    this.delayedQuery = "";
+    this.focusedIdx = null;
+    this.isOpen = false;
+    this.options = options;
+    this.openOnEmptyFocus = openOnEmptyFocus;
+    this.tokens = tokens; // Initialize tokens
+
+    makeObservable(this, {
+      query: observable,
+      delayedQuery: observable,
+      focusedIdx: observable,
+      isOpen: observable,
+      // set externally and replaced, not mutated
+      options: observable.ref,
+      tokens: observable.ref,
+      filteredOptions: computed,
+      focusedOption: computed,
+      handleArrowUp: action,
+      handleArrowDown: action,
+    });
+
+    // debounce
+    reaction(
+      () => this.query,
+      (query) => (this.delayedQuery = query),
+      { delay },
+    );
+
+    // Reset focused idx as query clears or dropdown closes
+    reaction(
+      () => ({
+        query: this.delayedQuery,
+        isOpen: this.isOpen,
+        filteredOptionsLength: this.filteredOptions.length,
+      }),
+      ({ query, isOpen, filteredOptionsLength }) => {
+        if (!isOpen || query === "") {
+          this.focusedIdx = null;
+        } else if (this.focusedIdx === null && filteredOptionsLength > 0) {
+          this.focusedIdx = 0;
+        } else if (
+          this.focusedIdx !== null &&
+          this.focusedIdx >= filteredOptionsLength
+        ) {
+          this.focusedIdx = 0;
+        }
+      },
+    );
+  }
+
+  get filteredOptions(): Option[] {
+    if (!this.options) return [];
+
+    // Remove any options already selected
+    let filtered = this.options.filter(
+      (option) => !this.tokens.includes(option.value),
+    );
+
+    // Only filter if query is not empty, otherwise show all if openOnEmptyFocus is true
+    if (!(this.delayedQuery === "" && this.openOnEmptyFocus)) {
+      filtered = filtered.filter((o) =>
+        o.value
+          .toLocaleLowerCase()
+          .includes(this.delayedQuery.toLocaleLowerCase()),
+      );
+    }
+
+    return filtered;
+  }
+
+  get focusedOption(): Option | null {
+    if (this.focusedIdx == null) return null;
+
+    return this.filteredOptions[this.focusedIdx];
+  }
+
+  handleArrowUp = () => {
+    if (this.focusedIdx != null && this.focusedIdx > 0) {
+      this.focusedIdx = this.focusedIdx - 1;
+    }
+  };
+
+  handleArrowDown = () => {
+    if (this.focusedIdx === null) {
+      this.focusedIdx = 0;
+      return;
+    }
+
+    if (this.focusedIdx < this.filteredOptions.length - 1) {
+      this.focusedIdx = this.focusedIdx + 1;
+    }
+  };
+}

--- a/src/views/documents/search/index.tsx
+++ b/src/views/documents/search/index.tsx
@@ -1,6 +1,6 @@
 import { observer } from "mobx-react-lite";
 import React from "react";
-import TagInput from "../../../components/TagInput";
+import TagInput from "../../../components/tag-input/TagInput";
 import { useSearchStore } from "../SearchStore";
 
 export const SearchInput = observer(() => {
@@ -13,7 +13,17 @@ export const SearchInput = observer(() => {
       onAdd={(token) => searchStore.addToken(token)}
       onRemove={(token) => searchStore.removeToken(token)}
       placeholder="Search notes"
-      dropdownEnabled={true}
+      suggestions={searchTags}
+      openOnEmptyFocus={true}
+      searchOnSelect={false}
     />
   );
 });
+
+const searchTags = [
+  { value: "in:", label: "Filter to specific journal" },
+  { value: "tag:", label: "Filter to specific tag" },
+  { value: "title:", label: "Filter by title" },
+  { value: "text:", label: "Search body text" },
+  { value: "before:", label: "Filter to notes before date (YYYY-MM-DD)" },
+];

--- a/src/views/documents/sidebar/TagsList.tsx
+++ b/src/views/documents/sidebar/TagsList.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { ClickableTag as Tag } from "../../../components/TagInput";
+import { ClickableTag as Tag } from "../../../components/tag-input/TagInput";
 import { useTags } from "../../../hooks/useTags";
 import { Card } from "./Card";
 

--- a/src/views/edit/editor/FrontMatter.tsx
+++ b/src/views/edit/editor/FrontMatter.tsx
@@ -1,11 +1,12 @@
 import { observer } from "mobx-react-lite";
-import React from "react";
+import React, { useMemo } from "react";
 import { DayPicker } from "react-day-picker";
 import * as D from "../../../components/DropdownMenu";
 import * as Popover from "../../../components/Popover";
-import TagInput from "../../../components/TagInput";
+import TagInput from "../../../components/tag-input/TagInput";
 import { useAutosizeTextarea } from "../../../hooks/useAutosizeTextarea";
 import { JournalResponse } from "../../../hooks/useClient";
+import { useTags } from "../../../hooks/useTags";
 import { TagTokenParser } from "../../documents/search/parsers/tag";
 import { EditableDocument } from "../EditableDocument";
 
@@ -19,6 +20,14 @@ const FrontMatter = observer(
   }) => {
     const journalSelectorOpenState = D.useOpenState();
     const datePickerOpenState = D.useOpenState();
+    const { tags: allTagsRaw } = useTags();
+
+    // todo: cleanup
+    const allTags = useMemo(() => {
+      return allTagsRaw.map((t) => ({
+        value: t,
+      }));
+    }, [allTagsRaw]);
 
     function onAddTag(token: string) {
       let tag = new TagTokenParser().parse(token)?.value;
@@ -150,6 +159,8 @@ const FrontMatter = observer(
             placeholder="Add tags"
             ghost={true}
             prefixHash={true}
+            suggestions={allTags}
+            openOnEmptyFocus={false}
           />
         </div>
       </>


### PR DESCRIPTION
- enhance TagInput in editor screen to auto-complete tags

Add's tag autocompletion to help speed up filling in tags and reduce errors (typos, which would create new / divergent tags). Not satisfied with implementation but tag inputs have many complications; need to do a better job finding a quality library here. 

<img width="407" height="312" alt="Screenshot 2025-11-30 at 8 57 38 AM" src="https://github.com/user-attachments/assets/28826224-791d-4b64-be7e-fbe475903f85" />

Closes #387 
