### PR TITLE
feat: improve spell check support

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "devDependencies": {
     "@electron/packager": "^18.1.3",
     "@electron/rebuild": "^3.7.2",
+    "electron-context-menu": "^4.0.4",
     "@radix-ui/colors": "^3.0.0",
     "@radix-ui/react-context-menu": "^2.2.1",
     "@radix-ui/react-dialog": "^1.1.1",

--- a/src/electron/index.ts
+++ b/src/electron/index.ts
@@ -1,13 +1,5 @@
-import {
-  BrowserWindow,
-  Menu,
-  MenuItem,
-  app,
-  dialog,
-  ipcMain,
-  protocol,
-  shell,
-} from "electron";
+import { BrowserWindow, app, dialog, ipcMain, protocol, shell } from "electron";
+import contextMenu from "electron-context-menu";
 import fs from "fs";
 import path from "path";
 import url, { fileURLToPath } from "url";
@@ -201,41 +193,15 @@ function createWindow() {
     });
 
     mainWindow.webContents.openDevTools();
-    setupInspectElement(mainWindow);
   }
-}
 
-/**
- * Sets up the "Inspect Element" context menu item for the main window.
- * This allows right-clicking on elements and inspect them using the
- * DevTools.
- * @param {Electron.Main.BrowserWindow} mainWindow
- */
-function setupInspectElement(mainWindow: BrowserWindow) {
-  // type is MenuItemConstructorOptions[]
-  let rightClickPosition: { x: number; y: number } | null = null;
-  const contextMenuTemplate: any[] = [
-    // todo: MenuItemConstructorOptions[]
-    {
-      label: "Inspect Element",
-      click: (item: MenuItem, focusedWindow?: BrowserWindow) => {
-        if (focusedWindow && rightClickPosition) {
-          focusedWindow.webContents.inspectElement(
-            rightClickPosition.x,
-            rightClickPosition.y,
-          );
-        }
-      },
-    },
-  ];
-
-  const contextMenu = Menu.buildFromTemplate(contextMenuTemplate);
-
-  mainWindow.webContents.on("context-menu", (event, params) => {
-    rightClickPosition = { x: params.x, y: params.y };
-    contextMenu.popup({
-      window: mainWindow,
-    });
+  // Setup context menu with spell checking support
+  contextMenu({
+    window: mainWindow,
+    showLearnSpelling: true,
+    showLookUpSelection: true,
+    showSearchWithGoogle: true,
+    showInspectElement: !app.isPackaged,
   });
 }
 

--- a/src/views/edit/editor/elements/CodeBlock.tsx
+++ b/src/views/edit/editor/elements/CodeBlock.tsx
@@ -79,7 +79,7 @@ export const CodeBlockElement = withRef<typeof PlateElement>(
         {...props}
       >
         <pre className="font-code overflow-x-auto rounded-md px-6 pb-4 pt-10 text-sm leading-[normal] [tab-size:2]">
-          <code>{children}</code>
+          <code spellCheck={false}>{children}</code>
         </pre>
         <div
           className="absolute right-2 top-2 z-10 select-none"

--- a/src/views/edit/editor/elements/CodeLeaf.tsx
+++ b/src/views/edit/editor/elements/CodeLeaf.tsx
@@ -4,7 +4,7 @@ import React from "react";
 export function CodeLeaf({ className, children, ...props }: PlateLeafProps) {
   return (
     <PlateLeaf asChild className={className} {...props}>
-      <code>{children}</code>
+      <code spellCheck={false}>{children}</code>
     </PlateLeaf>
   );
 }


### PR DESCRIPTION
- Replace custom inspect menu with electron-context-menu library
- Add dictionary features (Learn Spelling, Look Up) for spell checking
- Disable spell check in code blocks and inline code marks

Primary motivation was to get the squigglies gone especially in code blocks, and allow adding new words. Realized [Sindre's](https://github.com/sindresorhus/electron-context-menu) library handles / simplifies much of it 🙇‍♂️