### PR TITLE
fix: use body and system body fonts properly

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -19,8 +19,8 @@
     --font-heading: "Hubot Sans", var(--font-sans);
     --font-heading-2: var(--font-heading);
     --font-heading-3: var(--font-heading);
-    --font-system-body: var(--font-body);
-    --font-system-heading: var(--font-heading);
+    --font-system-body: "Mona Sans", var(--font-sans);
+    --font-system-heading: "Hubot Sans", var(--font-sans);
 
     --background: 0 0% 100%;
     --background-hint: hsl(0 0% 100%);

--- a/src/views/edit/editor/index.tsx
+++ b/src/views/edit/editor/index.tsx
@@ -78,7 +78,7 @@ const Editor = ({
 
             <div className="flex flex-grow pt-6" onClick={focusEditor}>
               {/* w-full ensures when content is empty, it has width, otherwise the cursor will be invisible */}
-              <PlateContent className="w-full" />
+              <PlateContent className="w-full font-body" />
             </div>
 
             {/* Add padding to bottom of editor without disrupting the scrollbar on the parent */}


### PR DESCRIPTION
- change --font-system-body and --font-system-heading to use explicit font stacks
- apply font-body class to PlateContent to use the --font-body CSS variable


Previously the fonts referenced --font-body and --font-heading, causing unintended coupling. And updating the body font would not actually change the note body content. This PR addresses both issues.


Fixes #417