### PR TITLE
feat: add fts5 search support

### DIFF
--- a/scripts/electron-test-runner.mjs
+++ b/scripts/electron-test-runner.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from "url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const projectRoot = path.resolve(__dirname, "..");
+const testMatches = process.argv.slice(2);
 
 // Find all electron test bundles
 function findElectronTestBundles(dir, files = []) {
@@ -32,6 +33,12 @@ console.log(`Found ${testFiles.length} electron test file(s)`);
 // Run tests sequentially
 async function runTests() {
   for (const testFile of testFiles) {
+    if (
+      testMatches.length > 0 &&
+      !testMatches.some((match) => testFile.includes(match))
+    )
+      continue;
+
     const relativeTestFile = path.relative(projectRoot, testFile);
     console.log(`\nRunning: ${relativeTestFile}`);
 

--- a/src/electron/migrations/20211005142122.sql
+++ b/src/electron/migrations/20211005142122.sql
@@ -24,7 +24,6 @@ CREATE TABLE  IF NOT EXISTS "documents" (
     "createdAt" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "title" TEXT,
-    "content" TEXT NOT NULL,
     "journal" TEXT NOT NULL,
     "frontmatter" TEXT NOT NULL,
     FOREIGN KEY ("journal") REFERENCES "journals" ("name") ON DELETE CASCADE ON UPDATE CASCADE


### PR DESCRIPTION
- add fts5 full text seach support

Adds support for more typical full text search. Previously text search was powered by a simple contains check, which would miss cases like 'organize' for a document with 'organizing'. See https://sqlite.org/fts5.html for full details