### PR TITLE
feat: add document counts to sidebar tags and improve styling

### DIFF
--- a/src/components/tag-input/TagInput.tsx
+++ b/src/components/tag-input/TagInput.tsx
@@ -257,7 +257,7 @@ export default TagInput;
 
 const tagVariants = cva(
   cn(
-    "mr-2 flex flex-shrink cursor-pointer items-center overflow-hidden text-ellipsis whitespace-nowrap rounded-sm border px-1 py-0.5 text-xs ",
+    "mr-1 flex flex-shrink cursor-pointer items-center overflow-hidden text-ellipsis whitespace-nowrap rounded-sm border px-1.5 py-1 text-xs hover:opacity-80 transition-opacity",
   ),
   {
     variants: {

--- a/src/hooks/useTags.ts
+++ b/src/hooks/useTags.ts
@@ -1,4 +1,5 @@
 import React from "react";
+import { TagWithCount } from "../preload/client/tags";
 import useClient from "./useClient";
 
 /**
@@ -17,6 +18,43 @@ export function useTags() {
     async function load() {
       try {
         const tags = await client.tags.all();
+        if (!isEffectMounted) return;
+
+        setTags(tags);
+        setLoading(false);
+      } catch (err: any) {
+        if (!isEffectMounted) return;
+
+        setError(err);
+        setLoading(false);
+      }
+    }
+
+    load();
+    return () => {
+      isEffectMounted = false;
+    };
+  }, []);
+
+  return { loading, tags, error };
+}
+
+/**
+ * Hook for loading tags with document counts.
+ */
+export function useTagsWithCounts() {
+  const [loading, setLoading] = React.useState(true);
+  const [tags, setTags] = React.useState<TagWithCount[]>([]);
+  const [error, setError] = React.useState(null);
+  const client = useClient();
+
+  React.useEffect(() => {
+    let isEffectMounted = true;
+    setLoading(true);
+
+    async function load() {
+      try {
+        const tags = await client.tags.allWithCounts();
         if (!isEffectMounted) return;
 
         setTags(tags);

--- a/src/preload/client/tags.ts
+++ b/src/preload/client/tags.ts
@@ -2,10 +2,28 @@ import { Knex } from "knex";
 
 export type ITagsClient = TagsClient;
 
+export interface TagWithCount {
+  tag: string;
+  count: number;
+}
+
 export class TagsClient {
   constructor(private knex: Knex) {}
 
   all = async (): Promise<string[]> => {
     return this.knex("document_tags").distinct("tag").pluck("tag");
+  };
+
+  allWithCounts = async (): Promise<TagWithCount[]> => {
+    const results = await this.knex("document_tags")
+      .select("tag")
+      .count("documentId as count")
+      .groupBy("tag")
+      .orderBy("tag", "asc");
+
+    return results.map((row: any) => ({
+      tag: row.tag,
+      count: Number(row.count),
+    }));
   };
 }

--- a/src/views/documents/sidebar/TagsList.tsx
+++ b/src/views/documents/sidebar/TagsList.tsx
@@ -1,14 +1,14 @@
 import React from "react";
 
 import { ClickableTag as Tag } from "../../../components/tag-input/TagInput";
-import { useTags } from "../../../hooks/useTags";
+import { useTagsWithCounts } from "../../../hooks/useTags";
 import { Card } from "./Card";
 
 /**
  * List of tags to search by.
  */
 export function TagsList(props: { search: (tag: string) => boolean }) {
-  const { loading, error, tags } = useTags();
+  const { loading, error, tags } = useTagsWithCounts();
 
   if (loading) {
     return "loading...";
@@ -24,11 +24,12 @@ export function TagsList(props: { search: (tag: string) => boolean }) {
       <div className="text-md mb-2 flex cursor-pointer items-center font-medium tracking-tight">
         Tags
       </div>
-      <div className="flex flex-wrap">
+      <div className="flex flex-wrap gap-2">
         {tags.map((t) => {
           return (
-            <Tag className="mb-1 mr-1" key={t} onClick={() => props.search(t)}>
-              #{t}
+            <Tag key={t.tag} onClick={() => props.search(t.tag)}>
+              <span>{t.tag}</span>
+              <span className="ml-0.5 text-xs opacity-60">({t.count})</span>
             </Tag>
           );
         })}


### PR DESCRIPTION
- add counts to tags on sidebar
- improve styling (little bigger / more readable)

See linked issue for originals

<img width="372" height="368" alt="updated tags appearance" src="https://github.com/user-attachments/assets/c402e994-b40f-4861-a503-c1f2aecea787" />


Fixes #414