### PR TITLE
feat: add document counts to journals and search results

### DIFF
--- a/src/views/documents/SearchStore.ts
+++ b/src/views/documents/SearchStore.ts
@@ -68,6 +68,7 @@ export class SearchStore {
   docs: SearchItem[] = [];
   loading = true;
   error: string | null = null;
+  count: number = 0;
   private journals: JournalsStore;
   private parser: SearchParser;
   // NOTE: Public so it can be updated by render calls, since useSearchParmas changes on
@@ -92,6 +93,7 @@ export class SearchStore {
       docs: observable,
       loading: observable,
       error: observable,
+      count: observable,
       _tokens: observable,
       setTokens: action,
       tokens: computed,
@@ -245,6 +247,10 @@ export class SearchStore {
       }
 
       this.docs = docs;
+
+      // Get total count for search results (without pagination)
+      const countQuery = this.tokensToQuery();
+      this.count = await this.client.documents.searchCount(countQuery);
     } catch (err) {
       console.error("Error with documents.search results", err);
       this.error = err instanceof Error ? err.message : JSON.stringify(err);

--- a/src/views/documents/index.tsx
+++ b/src/views/documents/index.tsx
@@ -104,6 +104,9 @@ function DocumentsContainer() {
 
   return (
     <Layout store={searchStore}>
+      <div className="mb-4 flex justify-end font-mono text-sm uppercase text-muted-foreground">
+        [{searchStore.count} DOCS FOUND]
+      </div>
       {groupedDocs.map((group) => (
         <div key={group.key} className="mb-8">
           <h2 className="mb-3 font-heading text-xl font-semibold text-accent-foreground">

--- a/src/views/documents/sidebar/JournalItem.tsx
+++ b/src/views/documents/sidebar/JournalItem.tsx
@@ -9,6 +9,7 @@ import { Icons } from "../../../components/icons";
 import { JournalResponse } from "../../../hooks/useClient";
 import { useIsMounted } from "../../../hooks/useIsMounted";
 import { useJournals } from "../../../hooks/useJournals";
+import { JournalWithCount } from "../../../preload/client/journals";
 import { SidebarStore } from "./store";
 
 export function JournalCreateForm({ done }: { done: () => any }) {
@@ -42,7 +43,7 @@ export const JournalItem = observer(
     isArchived,
     isDefault,
   }: {
-    journal: JournalResponse;
+    journal: JournalWithCount;
     store: SidebarStore;
     editing: boolean;
     isArchived: boolean;
@@ -63,6 +64,9 @@ export const JournalItem = observer(
               <a href="" onClick={() => store.search(journal.name)}>
                 {journal.name}
                 {isDefault ? "*" : ""}
+                <span className="ml-1 text-xs opacity-60">
+                  ({journal.count})
+                </span>
               </a>
             )}
           </div>


### PR DESCRIPTION
- add count display to documents page showing total matching documents
- display counts in journal sidebar items similar to tag counts

After #422 couldn't leave journals without counts. Heavy vibe assist but wow did it struggle with some basic styling. 

<img width="703" height="296" alt="Screenshot 2025-12-23 at 3 47 01 PM" src="https://github.com/user-attachments/assets/2c25bafa-b4c6-49ac-b01b-1871e87da333" />
<img width="392" height="240" alt="Screenshot 2025-12-23 at 3 47 10 PM" src="https://github.com/user-attachments/assets/df9acd1a-2619-496b-ae46-c310f38de7cf" />
