### PR TITLE
feat: add search negation

### DIFF
--- a/docs/search.md
+++ b/docs/search.md
@@ -1,0 +1,64 @@
+# Search System Architecture
+
+## Overview
+
+The search system in Chronicles is designed to convert raw user input strings into structured query objects called **Search Tokens**. It was inspired by the simple text searching of github issues; the implementation is rudiemntary but functional.
+
+## Pipeline Architecture
+
+The search parsing pipeline follows a router-based design pattern:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                       User Input                            │
+│                  "in:personal project-alpha"                │
+└─────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────┐
+│                       SearchParser                          │
+│                (src/views/documents/SearchParser.ts)        │
+│                                                             │
+│  1. Splits input into raw token strings                     │
+│  2. Checks for "prefix:value" pattern (Regex: ^(.*):(.*))   │
+│  3. Routes to specific TokenParser based on prefix          │
+└─────────────────────────────────────────────────────────────┘
+                              │
+          ┌───────────────────┼───────────────────┐
+          ▼                   ▼                   ▼
+┌───────────────────┐ ┌───────────────┐ ┌───────────────────┐
+│ JournalTokenParser│ │TextTokenParser│ │  TagTokenParser   │
+│   (prefix "in:")  │ │  (no prefix)  │ │   (prefix "tag:") │
+└───────────────────┘ └───────────────┘ └───────────────────┘
+          │                   │                   │
+          │                   │                   │
+          ▼                   ▼                   ▼
+┌─────────────────────────────────────────────────────────────┐
+│                        Search Tokens                        │
+│ [                                                           │
+│   { type: 'in', value: 'personal' },                        │
+│   { type: 'text', value: 'project-alpha' }                  │
+│ ]                                                           │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Search Tokens
+
+The system defines several token types (`src/views/documents/search/tokens.ts`):
+
+| Prefix    | Token Type     | Description                                 | Example             |
+| :-------- | :------------- | :------------------------------------------ | :------------------ |
+| `in:`     | `JournalToken` | Filters documents by journal name           | `in:work`           |
+| `tag:`    | `TagToken`     | Filters documents containing a specific tag | `tag:todo`          |
+| `title:`  | `TitleToken`   | Searches only within document titles        | `title:meeting`     |
+| `before:` | `BeforeToken`  | Filters documents created before a date     | `before:2023-01-01` |
+| `filter:` | `FilterToken`  | Advanced node matching (AST)                | _Internal use_      |
+| _(none)_  | `TextToken`    | Standard full-text search                   | `banana`            |
+
+## Components
+
+| Component              | Path                                      |
+| :--------------------- | :---------------------------------------- |
+| **Orchestrator**       | `src/views/documents/SearchParser.ts`     |
+| **Token Definitions**  | `src/views/documents/search/tokens.ts`    |
+| **Individual Parsers** | `src/views/documents/search/parsers/*.ts` |

--- a/src/preload/client/documents.ts
+++ b/src/preload/client/documents.ts
@@ -250,6 +250,19 @@ export class DocumentsClient {
         .whereIn("document_tags.tag", q.tags);
     }
 
+    if (q?.exclude?.tags?.length) {
+      query = query.whereNotExists(function () {
+        this.select("documentId")
+          .from("document_tags")
+          .whereRaw("document_tags.documentId = documents.id")
+          .whereIn("document_tags.tag", q.exclude!.tags!);
+      });
+    }
+
+    if (q?.exclude?.journals?.length) {
+      query = query.whereNotIn("journal", q.exclude.journals);
+    }
+
     // filter by title
     if (q?.titles?.length) {
       for (const title of q.titles) {

--- a/src/preload/client/search.electron-test.ts
+++ b/src/preload/client/search.electron-test.ts
@@ -1,0 +1,124 @@
+import { ipcRenderer } from "electron";
+import fs from "fs";
+import { Knex } from "knex";
+import assert from "node:assert";
+import { after, before, test } from "node:test";
+import path from "path";
+
+import { Client, setup } from "../test-util";
+import { createId } from "./util";
+
+let client: Client;
+let knex: Knex;
+let tempDir: string;
+let notesDir: string;
+
+before(async () => {
+  const setupResult = await setup();
+  client = setupResult.client;
+  knex = setupResult.knex;
+
+  // Get the temp directory from the current notesDir setting
+  notesDir = (await client.preferences.get("notesDir")) as string;
+  tempDir = path.dirname(notesDir);
+});
+
+after(async () => {
+  console.log("All tests complete, signaling completion to electron runner");
+  ipcRenderer.send("test-complete", 0);
+});
+
+test("search respects excludedTags", async () => {
+  const journalDir = path.join(notesDir, "test-journal");
+  fs.mkdirSync(journalDir, { recursive: true });
+
+  const createDoc = (title: string, tags: string[]) => {
+    const id = createId(new Date().getTime());
+    const content = `---
+title: ${title}
+tags: [${tags.map((t) => `"${t}"`).join(", ")}]
+createdAt: ${new Date().toISOString()}
+updatedAt: ${new Date().toISOString()}
+---
+
+# ${title}
+`;
+    fs.writeFileSync(path.join(journalDir, `${id}.md`), content);
+    return id;
+  };
+
+  const doc1Id = createDoc("Doc 1", ["alpha", "beta"]);
+  const doc2Id = createDoc("Doc 2", ["beta", "gamma"]);
+  const doc3Id = createDoc("Doc 3", ["alpha"]);
+  const doc4Id = createDoc("Doc 4", []); // No tags
+
+  // Index
+  await client.indexer.index(true);
+
+  // Test 1: Exclude 'gamma'
+  // Should return doc1, doc3, doc4. doc2 has gamma.
+  const res1 = await client.documents.search({
+    exclude: { tags: ["gamma"] },
+  });
+  const ids1 = res1.data.map((d) => d.id);
+  assert.ok(ids1.includes(doc1Id), "Should include doc1");
+  assert.ok(ids1.includes(doc3Id), "Should include doc3");
+  assert.ok(ids1.includes(doc4Id), "Should include doc4");
+  assert.ok(!ids1.includes(doc2Id), "Should exclude doc2 (has gamma)");
+
+  // Test 2: Include 'alpha', Exclude 'beta'
+  // Should return doc3 only. doc1 has alpha but also beta.
+  const res2 = await client.documents.search({
+    tags: ["alpha"],
+    exclude: { tags: ["beta"] },
+  });
+  const ids2 = res2.data.map((d) => d.id);
+  assert.ok(ids2.includes(doc3Id), "Should include doc3");
+  assert.ok(!ids2.includes(doc1Id), "Should exclude doc1 (has beta)");
+  assert.ok(
+    !ids2.includes(doc2Id),
+    "Should exclude doc2 (no alpha + has beta)",
+  );
+  assert.ok(!ids2.includes(doc4Id), "Should exclude doc4 (no alpha)");
+
+  // Test 3: Exclude multiple tags
+  // Exclude 'beta' and 'gamma'
+  // Should return doc3 and doc4.
+  const res3 = await client.documents.search({
+    exclude: { tags: ["beta", "gamma"] },
+  });
+  const ids3 = res3.data.map((d) => d.id);
+  assert.ok(ids3.includes(doc3Id), "Should include doc3");
+  assert.ok(ids3.includes(doc4Id), "Should include doc4");
+  assert.ok(!ids3.includes(doc1Id), "Should exclude doc1 (has beta)");
+  assert.ok(!ids3.includes(doc2Id), "Should exclude doc2 (has beta and gamma)");
+
+  // Test 4: Exclude journal
+  // Create docs in another journal
+  const journal2Dir = path.join(notesDir, "journal-excluded");
+  fs.mkdirSync(journal2Dir, { recursive: true });
+
+  const doc5Id = createId(new Date().getTime());
+  const doc5Content = `---
+title: Doc 5
+tags: []
+createdAt: ${new Date().toISOString()}
+updatedAt: ${new Date().toISOString()}
+---
+
+# Doc 5
+`;
+  fs.writeFileSync(path.join(journal2Dir, `${doc5Id}.md`), doc5Content);
+
+  // Re-index to pick up new journal/doc
+  await client.indexer.index(false);
+
+  // Search excluding "test-journal" (where docs 1-4 are)
+  const res4 = await client.documents.search({
+    exclude: { journals: ["test-journal"] },
+  });
+  const ids4 = res4.data.map((d) => d.id);
+
+  assert.ok(ids4.includes(doc5Id), "Should include doc5 from journal-excluded");
+  assert.ok(!ids4.includes(doc1Id), "Should exclude doc1 from test-journal");
+});

--- a/src/preload/client/types.ts
+++ b/src/preload/client/types.ts
@@ -70,6 +70,11 @@ export interface SearchRequest {
    */
   tags?: string[];
 
+  exclude?: {
+    tags?: string[];
+    journals?: string[];
+  };
+
   limit?: number;
 
   nodeMatch?: {

--- a/src/views/documents/SearchParser.ts
+++ b/src/views/documents/SearchParser.ts
@@ -57,14 +57,24 @@ export class SearchParser {
       return [parsers.text, parsers.text.parse(tokenStr)];
     }
 
-    const [, prefix, value] = matches;
+    let [, prefix, value] = matches;
     if (!value) return;
+
+    let excluded = false;
+    if (prefix.startsWith("-")) {
+      excluded = true;
+      prefix = prefix.substring(1);
+    }
 
     const parser: TokenParser = (parsers as any)[prefix];
     if (!parser) return;
 
     const parsedToken = parser.parse(value);
     if (!parsedToken) return;
+
+    if (excluded) {
+      (parsedToken as any).excluded = true;
+    }
 
     return [parser, parsedToken];
   }

--- a/src/views/documents/SearchStore.ts
+++ b/src/views/documents/SearchStore.ts
@@ -53,6 +53,10 @@ interface SearchQuery {
   titles?: string[];
   before?: string;
   tags?: string[];
+  exclude?: {
+    tags?: string[];
+    journals?: string[];
+  };
   texts?: string[];
   limit?: number;
 }
@@ -154,11 +158,19 @@ export class SearchStore {
   // todo: this might be better as a @computed get
   private tokensToQuery = (): SearchQuery => {
     const journals = this.tokens
-      .filter((t) => t.type === "in")
+      .filter((t) => t.type === "in" && !(t as any).excluded)
       .map((token) => token.value) as string[]; // assumes pre-validated by addToeken above
 
+    const excludedJournals = this.tokens
+      .filter((t) => t.type === "in" && (t as any).excluded)
+      .map((token) => token.value) as string[];
+
     const tags = this.tokens
-      .filter((t) => t.type === "tag")
+      .filter((t) => t.type === "tag" && !(t as any).excluded)
+      .map((t) => t.value) as string[];
+
+    const excludedTags = this.tokens
+      .filter((t) => t.type === "tag" && (t as any).excluded)
       .map((t) => t.value) as string[];
 
     // todo: Typescript doesn't know when I filter to type === 'title' its TitleTokens
@@ -176,7 +188,14 @@ export class SearchStore {
       before = beforeToken.value as string;
     }
 
-    return { journals, tags, titles, texts, before };
+    return {
+      journals,
+      tags,
+      exclude: { tags: excludedTags, journals: excludedJournals },
+      titles,
+      texts,
+      before,
+    };
   };
 
   /**

--- a/src/views/documents/search/parsers/in.ts
+++ b/src/views/documents/search/parsers/in.ts
@@ -3,7 +3,7 @@ import { JournalToken, SearchToken } from "../tokens";
 export class JournalTokenParser {
   prefix = "in:";
   serialize = (token: JournalToken) => {
-    return this.prefix + token.value;
+    return (token.excluded ? "-" : "") + this.prefix + token.value;
   };
 
   parse = (text: string): JournalToken | undefined => {
@@ -14,7 +14,14 @@ export class JournalTokenParser {
 
   add = (tokens: SearchToken[], token: JournalToken) => {
     // there can be only one of each named journal
-    if (tokens.find((t) => t.type === "in" && t.value === token.value)) {
+    if (
+      tokens.find(
+        (t) =>
+          t.type === "in" &&
+          t.value === token.value &&
+          (t as JournalToken).excluded === token.excluded,
+      )
+    ) {
       return tokens;
     }
 
@@ -32,7 +39,10 @@ export class JournalTokenParser {
       if (t.type !== "in") return true;
 
       // Remove if it matches...
-      return t.value !== token.value;
+      return (
+        t.value !== token.value ||
+        (t as JournalToken).excluded !== token.excluded
+      );
     });
   };
 }

--- a/src/views/documents/search/parsers/tag.ts
+++ b/src/views/documents/search/parsers/tag.ts
@@ -4,7 +4,7 @@ export class TagTokenParser {
   prefix = "tag:";
 
   serialize = (token: TagToken) => {
-    return this.prefix + token.value;
+    return (token.excluded ? "-" : "") + this.prefix + token.value;
   };
 
   parse = (text: string): TagToken | undefined => {
@@ -32,7 +32,14 @@ export class TagTokenParser {
 
   add = (tokens: SearchToken[], token: TagToken) => {
     // there can be only one of each named journal
-    if (tokens.find((t) => t.type === "tag" && t.value === token.value)) {
+    if (
+      tokens.find(
+        (t) =>
+          t.type === "tag" &&
+          t.value === token.value &&
+          (t as TagToken).excluded === token.excluded,
+      )
+    ) {
       return tokens;
     }
 
@@ -50,7 +57,9 @@ export class TagTokenParser {
       if (t.type !== "tag") return true;
 
       // Remove if it matches...
-      return t.value !== token.value;
+      return (
+        t.value !== token.value || (t as TagToken).excluded !== token.excluded
+      );
     });
   };
 }

--- a/src/views/documents/search/tokens.ts
+++ b/src/views/documents/search/tokens.ts
@@ -30,6 +30,7 @@ export type FilterToken = {
 export type JournalToken = {
   type: "in";
   value: string; // keyof Journals
+  excluded?: boolean;
 };
 
 /**
@@ -47,6 +48,7 @@ export type FocusToken = {
 export type TagToken = {
   type: "tag";
   value: string;
+  excluded?: boolean;
 };
 
 /**


### PR DESCRIPTION
- add tag (-tag:my_tag) and journal (-in:my_journal) negation to support searching all documents NOT matching a tag or journal

Main UX to support here is excluding work, personal, or side project journals from standard views; i most typically use this to switch from viewing personal, devlog, and work notes. Future changes will incorporate additional UX patterns to take advantage of these


Closes #406 