### PR TITLE
fix: cmd+e not mod+e for code shortcut

### DIFF
--- a/src/views/edit/editorv2/PlateContainer.tsx
+++ b/src/views/edit/editorv2/PlateContainer.tsx
@@ -200,7 +200,7 @@ export const PlateContainer = (props: Props) => {
       BoldPlugin,
       CodePlugin.configure({
         node: { component: CodeLeaf },
-        shortcuts: { toggle: { keys: "mod+e" } },
+        shortcuts: { toggle: { keys: "meta+e" } },
       }),
       ParagraphPlugin.withComponent(ParagraphElement),
       ItalicPlugin,


### PR DESCRIPTION

- fix ctrl+e on macos triggering code block rather than going to end of line

I use ctrl+e and ctrl+a to move forward back all the time while typing; this drove me nuts. 