### PR TITLE
feat: add date search filter and fix result count alignment

### DIFF
--- a/docs/search.md
+++ b/docs/search.md
@@ -52,6 +52,7 @@ The system defines several token types (`src/views/documents/search/tokens.ts`):
 | `tag:`    | `TagToken`     | Filters documents containing a specific tag | `tag:todo`          |
 | `title:`  | `TitleToken`   | Searches only within document titles        | `title:meeting`     |
 | `before:` | `BeforeToken`  | Filters documents created before a date     | `before:2023-01-01` |
+| `date:`   | `DateToken`    | Filters documents from a specific date      | `date:2025-02`      |
 | `filter:` | `FilterToken`  | Advanced node matching (AST)                | _Internal use_      |
 | _(none)_  | `TextToken`    | Standard full-text search                   | `banana`            |
 

--- a/src/views/documents/SearchParser.ts
+++ b/src/views/documents/SearchParser.ts
@@ -1,6 +1,7 @@
 import { SearchToken } from "./search/tokens";
 // import { FocusTokenParser } from "./search/parsers/focus";
 import { BeforeTokenParser } from "./search/parsers/before";
+import { DateTokenParser } from "./search/parsers/date";
 import { FilterTokenParser } from "./search/parsers/filter";
 import { JournalTokenParser } from "./search/parsers/in";
 import { TagTokenParser } from "./search/parsers/tag";
@@ -28,6 +29,7 @@ const parsers: Record<SearchToken["type"], TokenParser<any>> = {
   title: new TitleTokenParser(),
   text: new TextTokenParser(),
   before: new BeforeTokenParser(),
+  date: new DateTokenParser(),
 };
 
 /**

--- a/src/views/documents/index.tsx
+++ b/src/views/documents/index.tsx
@@ -104,7 +104,7 @@ function DocumentsContainer() {
 
   return (
     <Layout store={searchStore}>
-      <div className="text-muted-foreground mb-4 flex justify-end font-mono text-sm uppercase">
+      <div className="text-muted-foreground mb-4 flex justify-start font-mono text-sm uppercase">
         [{searchStore.count} DOCS FOUND]
       </div>
       {groupedDocs.map((group) => (

--- a/src/views/documents/search/SearchParser.test.ts
+++ b/src/views/documents/search/SearchParser.test.ts
@@ -208,6 +208,67 @@ describe("SearchParser", function () {
       });
     });
 
+    test("date: with year", function () {
+      const parser = new SearchParser();
+      const dateToken = parser.parseToken("date:2025");
+
+      assert.exists(dateToken);
+      assert.deepEqual(dateToken, {
+        type: "date",
+        value: "2025",
+      });
+    });
+
+    test("date: with year-month", function () {
+      const parser = new SearchParser();
+      const dateToken = parser.parseToken("date:2025-02");
+
+      assert.exists(dateToken);
+      assert.deepEqual(dateToken, {
+        type: "date",
+        value: "2025-02",
+      });
+    });
+
+    test("date: with full date", function () {
+      const parser = new SearchParser();
+      const dateToken = parser.parseToken("date:2025-02-05");
+
+      assert.exists(dateToken);
+      assert.deepEqual(dateToken, {
+        type: "date",
+        value: "2025-02-05",
+      });
+    });
+
+    test("date: invalid format", function () {
+      const parser = new SearchParser();
+      const dateToken = parser.parseToken("date:invalid");
+
+      assert.notExists(
+        dateToken,
+        "Invalid date format should return undefined",
+      );
+    });
+
+    test("date: replacement", function () {
+      const parser = new SearchParser();
+      const dateToken1 = parser.parseToken("date:2025");
+      const dateToken2 = parser.parseToken("date:2025-02");
+
+      const tokens = parser.mergeToken(
+        [dateToken1 as SearchToken],
+        dateToken2 as SearchToken,
+      );
+
+      // the second date: token should replace the first
+      assert.equal(tokens.length, 1);
+      assert.deepEqual(tokens[0], {
+        type: "date",
+        value: "2025-02",
+      });
+    });
+
     test("tag: with negation", function () {
       const parser = new SearchParser();
       const negativeTagToken = parser.parseToken("-tag:javascript");

--- a/src/views/documents/search/index.tsx
+++ b/src/views/documents/search/index.tsx
@@ -26,4 +26,8 @@ const searchTags = [
   { value: "title:", label: "Filter by title" },
   { value: "text:", label: "Search body text" },
   { value: "before:", label: "Filter to notes before date (YYYY-MM-DD)" },
+  {
+    value: "date:",
+    label: "Filter to notes from specific date (YYYY, YYYY-MM, or YYYY-MM-DD)",
+  },
 ];

--- a/src/views/documents/search/parsers/date.ts
+++ b/src/views/documents/search/parsers/date.ts
@@ -1,0 +1,53 @@
+import { DateToken, SearchToken } from "../tokens";
+
+export class DateTokenParser {
+  prefix = "date:";
+  serialize = (token: DateToken) => {
+    return this.prefix + token.value;
+  };
+
+  parse = (text: string): DateToken | undefined => {
+    if (!text) return;
+
+    // Validate ISO8601 date formats: YYYY, YYYY-MM, or YYYY-MM-DD
+    const yearPattern = /^\d{4}$/;
+    const yearMonthPattern = /^\d{4}-\d{2}$/;
+    const fullDatePattern = /^\d{4}-\d{2}-\d{2}$/;
+
+    if (
+      yearPattern.test(text) ||
+      yearMonthPattern.test(text) ||
+      fullDatePattern.test(text)
+    ) {
+      return { type: "date", value: text };
+    }
+
+    // Invalid format - return undefined to drop the term
+    // TODO: Show toast error "Use ISO8601 formatted dates"
+    return undefined;
+  };
+
+  add = (tokens: SearchToken[], token: DateToken) => {
+    // replace existing date token
+    const existing = tokens.find((t) => t.type === "date");
+    if (existing) {
+      if (existing.value !== token.value) {
+        const others = tokens.filter((t) => t !== existing);
+        others.push(token);
+        return others;
+      }
+      return tokens;
+    } else {
+      tokens.push(token);
+      return tokens;
+    }
+  };
+
+  remove = (tokens: SearchToken[], token: DateToken) => {
+    return tokens.filter((t) => {
+      // since we can have only one date token; keep
+      // everything that isn't a date token
+      return t.type !== "date";
+    });
+  };
+}

--- a/src/views/documents/search/tokens.ts
+++ b/src/views/documents/search/tokens.ts
@@ -75,6 +75,14 @@ export type BeforeToken = {
   value: string;
 };
 
+/**
+ * Searching documents created on a specific date (year, month, or day)
+ */
+export type DateToken = {
+  type: "date";
+  value: string;
+};
+
 export type SearchToken =
   | FilterToken
   | JournalToken
@@ -82,4 +90,5 @@ export type SearchToken =
   | TagToken
   | TitleToken
   | TextToken
-  | BeforeToken;
+  | BeforeToken
+  | DateToken;


### PR DESCRIPTION
- Add date: search filter supporting YYYY, YYYY-MM, and YYYY-MM-DD formats
- Add DateToken type and DateTokenParser
- Add comprehensive tests for date filtering
- Document date filter in search dropdown and docs/search.md
- Fix search result count alignment from right to left