### PR TITLE
Fix Lexical image markdown persistence and relative-path rendering

### DIFF
--- a/docs/designs/lexical-evaluation.md
+++ b/docs/designs/lexical-evaluation.md
@@ -16,7 +16,7 @@ MDAST remains used elsewhere in the app (indexer, search) but the editor pipelin
 
 ---
 
-## Current State (March 19, 2026)
+## Current State (March 20, 2026)
 
 **Done:**
 
@@ -27,9 +27,10 @@ MDAST remains used elsewhere in the app (indexer, search) but the editor pipelin
 - Code block syntax highlighting wiring via `@lexical/code` (`CodeHighlightNode` + `registerCodeHighlighting`)
 - Note links: custom `ChroniclesNoteLinkNode`, markdown transformer, `@`-trigger dropdown, click navigation
 - Regular links: floating toolbar (edit/unlink/open), paste-to-link conversion
-- 42 vitest cases across roundtrip, render contracts, and editor interactions
+- Images: custom `ChroniclesImageNode`, markdown roundtrip, drop/paste upload via `client.files.uploadImageBytes()`, max-size rendering constraints
+- Expanded vitest coverage across roundtrip, render contracts, and editor interactions, including image workflows
 
-**Not done:** remaining Phase 3 gaps (task list behavior, code-block language UI, list/code escape hatches, tab-indent behavior, `Cmd+Alt+8` parity).
+**Not done:** Remaining roadmap items in Phases 6-10, plus any deferred parity follow-ups noted in the phase sections below.
 
 ---
 
@@ -48,8 +49,8 @@ Port remaining text formatting and block types to reach parity with Plate.
 | Strikethrough     | `~~text~~` autoformat                                | `Cmd+Shift+S` + markdown roundtrip                               | Verify `~~` typing trigger explicitly                                    |
 | Underline         | `Cmd+U`                                              | `Cmd+U`                                                          | Done — note: underline has no markdown syntax, Cmd+U applies format only |
 | Inline code       | `` `text` `` autoformat, `Cmd+E`                     | `Cmd+E` + backtick trigger                                       | Done                                                                     |
-| Code blocks       | ` ``` ` autoformat, `Cmd+Alt+8`, syntax highlighting | Fenced trigger + syntax-highlighting wiring + language roundtrip | Add `Cmd+Alt+8`; add language config UI                                  |
-| Task lists        | `[ ] ` autoformat (broken in Plate)                  | No                                                               | Add `ListItemNode` checkbox support or skip if Plate's was broken        |
+| Code blocks       | ` ``` ` autoformat, `Cmd+Alt+8`, syntax highlighting | Fenced trigger + syntax-highlighting wiring + language roundtrip | Done — `Cmd+Alt+8` toggle and language picker UI shipped                 |
+| Task lists        | `[ ] ` autoformat (broken in Plate)                  | Checklist markdown roundtrip + checklist rendering               | Typing autoformat can remain deferred; Plate behavior was already broken |
 | Headings typing   | `# `, `## `, `### `                                  | Via `MarkdownShortcutPlugin`                                     | Verified with explicit typing tests                                      |
 | Blockquote typing | `> `                                                 | Via `MarkdownShortcutPlugin`                                     | Verified with explicit typing tests                                      |
 | Lists typing      | `- `, `1. `                                          | Via `MarkdownShortcutPlugin`                                     | Verified with explicit typing tests                                      |
@@ -66,14 +67,13 @@ Port remaining text formatting and block types to reach parity with Plate.
 
 **Exit criteria:** All Plate marks and block types either work in Lexical or are explicitly deferred with rationale.
 
-**Observed constraints (March 18, 2026):**
+**Observed constraints (March 20, 2026):**
 
-- List typing triggers (`- `, `1. `) work, but there is currently no reliable escape via double-enter. New lines continue list context.
-- Tab does not currently indent list items in Lexical mode; tab moves focus out of the editor.
-- Code block syntax highlighting works when a language is already present in markdown (for example by toggling to markdown mode, setting fence language, then toggling back to Lexical).
-- There is currently no in-editor language picker/config UI for code blocks.
-- There is currently no escape behavior from code blocks (for example empty-line Enter exit).
-- Both list/code-block escape gaps are expected to be addressed by future keyboard escape-hatch behavior (Phase 8 / dedicated escape plugin).
+- Double-enter list escape is implemented in Lexical mode.
+- Tab/Shift+Tab list indent and outdent are implemented in Lexical mode.
+- Code language can be changed from an in-editor picker UI.
+- Code-block escape behaviors are implemented (`Cmd+Enter`, and Enter on empty trailing line).
+- Any remaining keyboard UX deltas should be treated as polish follow-ups, not parity blockers.
 
 ---
 
@@ -88,8 +88,8 @@ Note link navigation and markdown IO already work. This phase completes the crea
 | Arrow keys + Enter to insert          | Done                     |
 | Click on existing note link navigates | Done                     |
 | Dropdown positioning                  | Verify — may need polish |
-| Empty state / no results              | Verify — add test        |
-| Escape closes dropdown                | Verify — add test        |
+| Empty state / no results              | Done                     |
+| Escape closes dropdown                | Done                     |
 
 **Vitests:**
 
@@ -107,28 +107,28 @@ Note link navigation and markdown IO already work. This phase completes the crea
 
 Images are local-first: stored as attachments, referenced via `chronicles://` URLs.
 
-| Feature                  | Work needed                                                                                             |
+| Feature                  | Status                                                                                                  |
 | ------------------------ | ------------------------------------------------------------------------------------------------------- |
-| Image rendering          | Custom `ImageNode` (void/decorator), renders `<img>` with attachment URL resolution                     |
-| Drag-and-drop upload     | Plugin intercepts `DROP` events with image files, calls `client.files.uploadImageBytes()`, inserts node |
-| Paste upload             | Same plugin intercepts `PASTE` events with image data                                                   |
-| Image markdown roundtrip | `![alt](url)` import/export via transformer                                                             |
-| Max display size         | CSS constraint (max-height 320px, max-width 80% — match Plate)                                          |
+| Image rendering          | Done — custom `ChroniclesImageNode` decorator renders `<img>` with attachment URLs                      |
+| Drag-and-drop upload     | Done — `LexicalImageUploadPlugin` intercepts `DROP` and inserts uploaded image nodes                    |
+| Paste upload             | Done — `LexicalImageUploadPlugin` intercepts `PASTE` image files and inserts uploaded image nodes       |
+| Image markdown roundtrip | Done — custom markdown transformer roundtrips `![alt](url)`                                             |
+| Max display size         | Done — image class constrains display (`max-height: 320px`, `max-width: 80%`) to match Plate-era sizing |
 
 **Not porting (defer to later):**
 
 - Image resize handles (Plate doesn't have them either — planned for bun-client era)
 - Remote image blocking (keep, but implement when wiring up the full media pipeline)
 
-**Vitests:**
+**Vitests (implemented):**
 
-- Image markdown roundtrip: `![alt](../path.png)` imports and exports correctly
-- ImageNode renders `<img>` with correct src and alt
-- Drag-and-drop: simulated drop event with File triggers upload and node insertion
-- Paste: simulated paste event with image data triggers upload and node insertion
+- Image markdown roundtrip: `![alt](url)` imports and exports correctly
+- `ChroniclesImageNode` renders `<img>` with correct src and alt
+- Drag-and-drop: simulated drop event with `File` triggers upload and node insertion
+- Paste: simulated paste event with image file data triggers upload and node insertion
 - Multiple consecutive images render independently (no gallery yet)
 
-**Exit criteria:** Single images display and can be added via drag-drop/paste. Markdown fidelity preserved.
+**Exit criteria:** Completed (March 20, 2026). Single images display and can be added via drag-drop/paste. Markdown fidelity preserved.
 
 ---
 

--- a/src/views/edit/lexical/ChroniclesImageNode.tsx
+++ b/src/views/edit/lexical/ChroniclesImageNode.tsx
@@ -1,0 +1,118 @@
+import {
+  $applyNodeReplacement,
+  DecoratorNode,
+  type LexicalNode,
+  type NodeKey,
+  type SerializedLexicalNode,
+} from "lexical";
+import React from "react";
+
+export interface SerializedChroniclesImageNode extends SerializedLexicalNode {
+  altText: string;
+  src: string;
+  type: "chronicles-image";
+  version: 1;
+}
+
+export class ChroniclesImageNode extends DecoratorNode<JSX.Element> {
+  __src: string;
+  __altText: string;
+
+  static getType(): string {
+    return "chronicles-image";
+  }
+
+  static clone(node: ChroniclesImageNode): ChroniclesImageNode {
+    return new ChroniclesImageNode(node.__src, node.__altText, node.__key);
+  }
+
+  static importJSON(
+    serializedNode: SerializedChroniclesImageNode,
+  ): ChroniclesImageNode {
+    return $createChroniclesImageNode(
+      serializedNode.src,
+      serializedNode.altText,
+    ).updateFromJSON(serializedNode);
+  }
+
+  constructor(src: string, altText = "", key?: NodeKey) {
+    super(key);
+    this.__src = src;
+    this.__altText = altText;
+  }
+
+  createDOM(): HTMLElement {
+    const container = document.createElement("div");
+    container.className = "mb-3";
+    return container;
+  }
+
+  updateDOM(): false {
+    return false;
+  }
+
+  decorate(): JSX.Element {
+    return (
+      <img
+        src={this.__src}
+        alt={this.__altText}
+        className="max-h-[320px] max-w-[80%] rounded-md object-contain"
+      />
+    );
+  }
+
+  exportJSON(): SerializedChroniclesImageNode {
+    return {
+      ...super.exportJSON(),
+      altText: this.getAltText(),
+      src: this.getSrc(),
+      type: "chronicles-image",
+      version: 1,
+    };
+  }
+
+  isInline(): false {
+    return false;
+  }
+
+  canInsertTextAfter(): false {
+    return false;
+  }
+
+  canInsertTextBefore(): false {
+    return false;
+  }
+
+  getSrc(): string {
+    return this.getLatest().__src;
+  }
+
+  getAltText(): string {
+    return this.getLatest().__altText;
+  }
+
+  setSrc(src: string): void {
+    const writable = this.getWritable();
+    writable.__src = src;
+  }
+
+  setAltText(altText: string): void {
+    const writable = this.getWritable();
+    writable.__altText = altText;
+  }
+}
+
+export function $createChroniclesImageNode(
+  src: string,
+  altText = "",
+): ChroniclesImageNode {
+  return $applyNodeReplacement(
+    new ChroniclesImageNode(src, altText),
+  ) as ChroniclesImageNode;
+}
+
+export function $isChroniclesImageNode(
+  node: LexicalNode | null | undefined,
+): node is ChroniclesImageNode {
+  return node instanceof ChroniclesImageNode;
+}

--- a/src/views/edit/lexical/LexicalBasedEditor.tsx
+++ b/src/views/edit/lexical/LexicalBasedEditor.tsx
@@ -15,6 +15,7 @@ import { LexicalBlockShortcutsPlugin } from "./LexicalBlockShortcutsPlugin";
 import { LexicalCodeHighlightPlugin } from "./LexicalCodeHighlightPlugin";
 import { LexicalCodeLanguagePlugin } from "./LexicalCodeLanguagePlugin";
 import { LexicalFormattingShortcutsPlugin } from "./LexicalFormattingShortcutsPlugin";
+import { LexicalImageUploadPlugin } from "./LexicalImageUploadPlugin";
 import { LexicalLinkToolbarPlugin } from "./LexicalLinkToolbarPlugin";
 import { LexicalListBehaviorPlugin } from "./LexicalListBehaviorPlugin";
 import { LexicalNoteLinkPlugin } from "./LexicalNoteLinkPlugin";
@@ -133,6 +134,7 @@ export function LexicalBasedEditor({
         <LexicalFormattingShortcutsPlugin />
         <LexicalBlockShortcutsPlugin />
         <LexicalListBehaviorPlugin />
+        <LexicalImageUploadPlugin />
         <LexicalPasteLinkPlugin />
         <LexicalLinkToolbarPlugin />
         <OnChangePlugin

--- a/src/views/edit/lexical/LexicalBlockShortcutsPlugin.tsx
+++ b/src/views/edit/lexical/LexicalBlockShortcutsPlugin.tsx
@@ -39,8 +39,11 @@ function isSelectionAtCodeBlockEnd(
     return anchorOffset === anchorNode.getChildrenSize();
   }
 
+  const parent = anchorNode.getParent();
   return (
-    anchorNode.getParent()?.is(codeNode) && anchorNode.getNextSibling() === null
+    parent !== null &&
+    parent.is(codeNode) &&
+    anchorNode.getNextSibling() === null
   );
 }
 

--- a/src/views/edit/lexical/LexicalImageUploadPlugin.tsx
+++ b/src/views/edit/lexical/LexicalImageUploadPlugin.tsx
@@ -152,30 +152,33 @@ export function LexicalImageUploadPlugin(): null {
       const client = chronicles?.getClient?.();
       const uploadImageBytes = client?.files?.uploadImageBytes;
       if (typeof uploadImageBytes !== "function") {
+        toast.warning("Image upload is not available.");
         return;
       }
 
-      const uploaded: Array<{ altText: string; url: string }> = [];
-      for (const file of files) {
-        const buffer = await file.arrayBuffer();
-        const uploadResult = parseUploadResult(
-          await uploadImageBytes(buffer, file.name),
-        );
-        if (!uploadResult) {
-          continue;
-        }
-
-        if (uploadResult.warning?.code) {
-          toast.warning(
-            buildImageWarningMessage(file.name, uploadResult.warning.code),
+      const results = await Promise.all(
+        files.map(async (file) => {
+          const buffer = await file.arrayBuffer();
+          const uploadResult = parseUploadResult(
+            await uploadImageBytes(buffer, file.name),
           );
-        }
+          if (!uploadResult) {
+            return null;
+          }
 
-        uploaded.push({
-          altText: file.name,
-          url: uploadResult.url,
-        });
-      }
+          if (uploadResult.warning?.code) {
+            toast.warning(
+              buildImageWarningMessage(file.name, uploadResult.warning.code),
+            );
+          }
+
+          return { altText: file.name, url: uploadResult.url };
+        }),
+      );
+
+      const uploaded = results.filter(
+        (r): r is { altText: string; url: string } => r !== null,
+      );
 
       if (uploaded.length === 0) {
         return;
@@ -193,43 +196,35 @@ export function LexicalImageUploadPlugin(): null {
   );
 
   React.useEffect(() => {
-    return editor.registerCommand(
+    function handleImageTransfer(event: Event): boolean {
+      const files = extractImageFiles(event);
+      if (files.length === 0) {
+        return false;
+      }
+
+      event.preventDefault();
+      void uploadAndInsertImages(files).catch((error) => {
+        console.error("Failed to upload images", error);
+        toast.error("Failed to upload image.");
+      });
+      return true;
+    }
+
+    const removeDrop = editor.registerCommand(
       DROP_COMMAND,
-      (event) => {
-        const files = extractImageFiles(event);
-        if (files.length === 0) {
-          return false;
-        }
-
-        event.preventDefault();
-        void uploadAndInsertImages(files).catch((error) => {
-          console.error("Failed to upload dropped images", error);
-          toast.error("Failed to upload dropped image.");
-        });
-        return true;
-      },
+      handleImageTransfer,
       COMMAND_PRIORITY_HIGH,
     );
-  }, [editor, uploadAndInsertImages]);
-
-  React.useEffect(() => {
-    return editor.registerCommand(
+    const removePaste = editor.registerCommand(
       PASTE_COMMAND,
-      (event) => {
-        const files = extractImageFiles(event);
-        if (files.length === 0) {
-          return false;
-        }
-
-        event.preventDefault();
-        void uploadAndInsertImages(files).catch((error) => {
-          console.error("Failed to upload pasted images", error);
-          toast.error("Failed to upload pasted image.");
-        });
-        return true;
-      },
+      handleImageTransfer,
       COMMAND_PRIORITY_HIGH,
     );
+
+    return () => {
+      removeDrop();
+      removePaste();
+    };
   }, [editor, uploadAndInsertImages]);
 
   return null;

--- a/src/views/edit/lexical/LexicalImageUploadPlugin.tsx
+++ b/src/views/edit/lexical/LexicalImageUploadPlugin.tsx
@@ -1,0 +1,236 @@
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import {
+  $insertNodes,
+  COMMAND_PRIORITY_HIGH,
+  DROP_COMMAND,
+  PASTE_COMMAND,
+} from "lexical";
+import React from "react";
+import { toast } from "sonner";
+import { isImageUrl } from "../../../hooks/images";
+import { $createChroniclesImageNode } from "./ChroniclesImageNode";
+
+type UploadImageWarningCode =
+  | "decode_missing_plugin"
+  | "decode_failed"
+  | "process_failed";
+
+type UploadImageResult = {
+  url: string;
+  warning?: {
+    code: UploadImageWarningCode;
+  };
+};
+
+function buildImageWarningMessage(
+  filename: string,
+  code: UploadImageWarningCode,
+) {
+  switch (code) {
+    case "decode_missing_plugin":
+      return `Image "${filename}" could not be processed (missing decoder). Saved original file; preview may fail.`;
+    case "decode_failed":
+      return `Image "${filename}" could not be processed. Saved original file; preview may fail.`;
+    default:
+      return `Image "${filename}" processing failed. Saved original file; preview may fail.`;
+  }
+}
+
+function isFileLike(value: unknown): value is File {
+  if (typeof File !== "undefined" && value instanceof File) {
+    return true;
+  }
+
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as File).name === "string" &&
+    typeof (value as File).type === "string" &&
+    typeof (value as File).arrayBuffer === "function"
+  );
+}
+
+function toFileArray(files: unknown): File[] {
+  if (!files || typeof files !== "object") {
+    return [];
+  }
+
+  if (Array.isArray(files)) {
+    return files.filter(isFileLike);
+  }
+
+  const listLike = files as {
+    length?: number;
+    [index: number]: unknown;
+  };
+  if (typeof listLike.length !== "number") {
+    return [];
+  }
+
+  return Array.from(
+    { length: listLike.length },
+    (_, index) => listLike[index],
+  ).filter(isFileLike);
+}
+
+function getFilesFromDataTransfer(dataTransfer: unknown): File[] {
+  if (!dataTransfer || typeof dataTransfer !== "object") {
+    return [];
+  }
+
+  const maybeFiles = (dataTransfer as { files?: unknown }).files;
+  const files = toFileArray(maybeFiles);
+  if (files.length > 0) {
+    return files;
+  }
+
+  const items = (dataTransfer as { items?: unknown }).items;
+  if (!items || typeof items !== "object") {
+    return [];
+  }
+
+  const itemList = toFileArray(items as unknown[]);
+  if (itemList.length > 0) {
+    return itemList;
+  }
+
+  const listLike = items as {
+    length?: number;
+    [index: number]: {
+      kind?: string;
+      getAsFile?: () => File | null;
+    };
+  };
+  if (typeof listLike.length !== "number") {
+    return [];
+  }
+
+  return Array.from({ length: listLike.length }, (_, index) => listLike[index])
+    .map((item) =>
+      item?.kind === "file" && typeof item.getAsFile === "function"
+        ? item.getAsFile()
+        : null,
+    )
+    .filter(isFileLike);
+}
+
+function extractImageFiles(event: unknown): File[] {
+  if (!event || typeof event !== "object") {
+    return [];
+  }
+
+  const dataTransfer = (event as { dataTransfer?: unknown }).dataTransfer;
+  const clipboardData = (event as { clipboardData?: unknown }).clipboardData;
+
+  return getFilesFromDataTransfer(dataTransfer ?? clipboardData).filter(
+    (file) => file.type.startsWith("image/") || isImageUrl(file.name),
+  );
+}
+
+function parseUploadResult(result: unknown): UploadImageResult | null {
+  if (typeof result === "string") {
+    return { url: result };
+  }
+
+  if (
+    typeof result === "object" &&
+    result !== null &&
+    typeof (result as UploadImageResult).url === "string"
+  ) {
+    return result as UploadImageResult;
+  }
+
+  return null;
+}
+
+export function LexicalImageUploadPlugin(): null {
+  const [editor] = useLexicalComposerContext();
+
+  const uploadAndInsertImages = React.useCallback(
+    async (files: File[]) => {
+      const chronicles = (window as any).chronicles;
+      const client = chronicles?.getClient?.();
+      const uploadImageBytes = client?.files?.uploadImageBytes;
+      if (typeof uploadImageBytes !== "function") {
+        return;
+      }
+
+      const uploaded: Array<{ altText: string; url: string }> = [];
+      for (const file of files) {
+        const buffer = await file.arrayBuffer();
+        const uploadResult = parseUploadResult(
+          await uploadImageBytes(buffer, file.name),
+        );
+        if (!uploadResult) {
+          continue;
+        }
+
+        if (uploadResult.warning?.code) {
+          toast.warning(
+            buildImageWarningMessage(file.name, uploadResult.warning.code),
+          );
+        }
+
+        uploaded.push({
+          altText: file.name,
+          url: uploadResult.url,
+        });
+      }
+
+      if (uploaded.length === 0) {
+        return;
+      }
+
+      editor.update(() => {
+        $insertNodes(
+          uploaded.map((image) =>
+            $createChroniclesImageNode(image.url, image.altText),
+          ),
+        );
+      });
+    },
+    [editor],
+  );
+
+  React.useEffect(() => {
+    return editor.registerCommand(
+      DROP_COMMAND,
+      (event) => {
+        const files = extractImageFiles(event);
+        if (files.length === 0) {
+          return false;
+        }
+
+        event.preventDefault();
+        void uploadAndInsertImages(files).catch((error) => {
+          console.error("Failed to upload dropped images", error);
+          toast.error("Failed to upload dropped image.");
+        });
+        return true;
+      },
+      COMMAND_PRIORITY_HIGH,
+    );
+  }, [editor, uploadAndInsertImages]);
+
+  React.useEffect(() => {
+    return editor.registerCommand(
+      PASTE_COMMAND,
+      (event) => {
+        const files = extractImageFiles(event);
+        if (files.length === 0) {
+          return false;
+        }
+
+        event.preventDefault();
+        void uploadAndInsertImages(files).catch((error) => {
+          console.error("Failed to upload pasted images", error);
+          toast.error("Failed to upload pasted image.");
+        });
+        return true;
+      },
+      COMMAND_PRIORITY_HIGH,
+    );
+  }, [editor, uploadAndInsertImages]);
+
+  return null;
+}

--- a/src/views/edit/lexical/lexical.vitest.tsx
+++ b/src/views/edit/lexical/lexical.vitest.tsx
@@ -9,6 +9,7 @@ import {
   $getRoot,
   $nodesOfType,
   CONTROLLED_TEXT_INSERTION_COMMAND,
+  DROP_COMMAND,
   KEY_DOWN_COMMAND,
   KEY_ENTER_COMMAND,
   KEY_ESCAPE_COMMAND,
@@ -52,12 +53,23 @@ type NoteSearchQuery = {
   titles?: string[];
 };
 
-function mockChroniclesSearch(
-  resolver: (query: NoteSearchQuery) => NoteSearchResult[],
-) {
+type UploadImageBytesFn = (
+  arrayBuffer: ArrayBuffer,
+  filename?: string,
+) => Promise<{ url: string } | string>;
+
+function mockChroniclesClient({
+  searchResolver = () => [],
+  uploadImageBytes = vi.fn(async (_buffer, filename = "upload.png") => ({
+    url: `chronicles://../_attachments/${filename}`,
+  })),
+}: {
+  searchResolver?: (query: NoteSearchQuery) => NoteSearchResult[];
+  uploadImageBytes?: UploadImageBytesFn;
+} = {}) {
   const searchMock = vi.fn(
     async (query: NoteSearchQuery): Promise<{ data: NoteSearchResult[] }> => ({
-      data: resolver(query),
+      data: searchResolver(query),
     }),
   );
 
@@ -67,11 +79,20 @@ function mockChroniclesSearch(
         documents: {
           search: searchMock,
         },
+        files: {
+          uploadImageBytes,
+        },
       };
     },
   };
 
-  return searchMock;
+  return { searchMock, uploadImageBytes };
+}
+
+function mockChroniclesSearch(
+  resolver: (query: NoteSearchQuery) => NoteSearchResult[],
+) {
+  return mockChroniclesClient({ searchResolver: resolver }).searchMock;
 }
 
 afterEach(() => {
@@ -144,6 +165,38 @@ function createPasteEvent(plainText: string): ClipboardEvent {
   return event;
 }
 
+function createImagePasteEvent(file: File): ClipboardEvent {
+  const event = new Event("paste", {
+    bubbles: true,
+    cancelable: true,
+  }) as ClipboardEvent;
+  Object.defineProperty(event, "clipboardData", {
+    value: {
+      files: [file],
+      getData(type: string): string {
+        return type === "text/plain" ? "" : "";
+      },
+    } as unknown as Pick<DataTransfer, "files" | "getData">,
+  });
+  return event;
+}
+
+function createDropEvent(file: File): DragEvent {
+  const event = new Event("drop", {
+    bubbles: true,
+    cancelable: true,
+  }) as DragEvent;
+  Object.defineProperty(event, "dataTransfer", {
+    value: {
+      files: [file],
+      getData(): string {
+        return "";
+      },
+    } as unknown as Pick<DataTransfer, "files" | "getData">,
+  });
+  return event;
+}
+
 async function typeWithLexical(
   editor: LexicalEditor,
   text: string,
@@ -203,6 +256,28 @@ describe("lexical migration spike", () => {
     );
   });
 
+  it("roundtrips image markdown through Lexical", () => {
+    const markdown = "![A tidy desk](../_attachments/desk.png)";
+    expect(roundtripLexicalMarkdown(markdown)).toBe(markdown);
+  });
+
+  it("roundtrips consecutive images through Lexical", () => {
+    const markdown = [
+      "![one](../_attachments/one.png)",
+      "![two](../_attachments/two.png)",
+    ].join("\n");
+    const roundtripped = roundtripLexicalMarkdown(markdown);
+    expect(roundtripped).toContain("![one](../_attachments/one.png)");
+    expect(roundtripped).toContain("![two](../_attachments/two.png)");
+  });
+
+  it("normalizes chronicles image URLs back to markdown-relative paths", () => {
+    const markdown = "![A tidy desk](chronicles://../_attachments/desk.png)";
+    expect(roundtripLexicalMarkdown(markdown)).toBe(
+      "![A tidy desk](../_attachments/desk.png)",
+    );
+  });
+
   it("renders the lexical replacement seam", () => {
     const onMarkdownChange = vi.fn();
 
@@ -232,6 +307,39 @@ describe("lexical migration spike", () => {
 
     const link = await screen.findByRole("link", { name: "Like this" });
     expect(link.getAttribute("href")).toBe("https://foo.com");
+  });
+
+  it("renders markdown images as img elements in the editor DOM", async () => {
+    renderEditorWithRoutes(
+      "![A tidy desk](chronicles://../_attachments/desk.png)",
+    );
+
+    const image = await screen.findByRole("img", { name: "A tidy desk" });
+    expect(image.getAttribute("src")).toBe(
+      "chronicles://../_attachments/desk.png",
+    );
+  });
+
+  it("renders relative markdown image URLs using chronicles protocol", async () => {
+    renderEditorWithRoutes("![A tidy desk](../_attachments/desk.png)");
+
+    const image = await screen.findByRole("img", { name: "A tidy desk" });
+    expect(image.getAttribute("src")).toBe(
+      "chronicles://../_attachments/desk.png",
+    );
+  });
+
+  it("renders consecutive markdown images independently", async () => {
+    renderEditorWithRoutes(
+      [
+        "![one](chronicles://../_attachments/one.png)",
+        "![two](chronicles://../_attachments/two.png)",
+      ].join("\n"),
+    );
+
+    await waitFor(() => {
+      expect(screen.getAllByRole("img")).toHaveLength(2);
+    });
   });
 
   it("navigates directly when clicking a chronicles note link", async () => {
@@ -1572,6 +1680,123 @@ describe("lexical migration spike", () => {
       const closeFenceIndex = latestMarkdown?.lastIndexOf("```") ?? -1;
       expect(afterIndex).toBeGreaterThan(closeFenceIndex);
     });
+  });
+
+  it("uploads dropped image files and inserts image markdown", async () => {
+    const onMarkdownChange = vi.fn();
+    const uploadImageBytes = vi.fn(async (_buffer: ArrayBuffer) => ({
+      url: "chronicles://../_attachments/dropped.png",
+    }));
+    mockChroniclesClient({ uploadImageBytes });
+    let lexicalEditor: LexicalEditor | null = null;
+
+    render(
+      <MemoryRouter>
+        <LexicalBasedEditor
+          initialMarkdown=""
+          onMarkdownChange={onMarkdownChange}
+          onEditorReady={(editor) => {
+            lexicalEditor = editor;
+          }}
+        />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(lexicalEditor).not.toBeNull();
+    });
+
+    const editor = screen.getByLabelText("Minimal replacement editor");
+    const file = new File(["png-bytes"], "dropped.png", { type: "image/png" });
+    await act(async () => {
+      fireEvent.focus(editor);
+      lexicalEditor!.update(() => {
+        $getRoot().selectStart();
+      });
+      lexicalEditor!.dispatchCommand(DROP_COMMAND, createDropEvent(file));
+    });
+
+    await waitFor(() => {
+      expect(uploadImageBytes).toHaveBeenCalledWith(
+        expect.any(ArrayBuffer),
+        "dropped.png",
+      );
+    });
+
+    const image = await screen.findByRole("img", { name: "dropped.png" });
+    expect(image.getAttribute("src")).toBe(
+      "chronicles://../_attachments/dropped.png",
+    );
+
+    await waitFor(() => {
+      expect(onMarkdownChange).toHaveBeenCalled();
+    });
+    const latestMarkdown = onMarkdownChange.mock.calls.at(-1)?.[0] as
+      | string
+      | undefined;
+    expect(latestMarkdown).toContain(
+      "![dropped.png](../_attachments/dropped.png)",
+    );
+  });
+
+  it("uploads pasted image files and inserts image markdown", async () => {
+    const onMarkdownChange = vi.fn();
+    const uploadImageBytes = vi.fn(async (_buffer: ArrayBuffer) => ({
+      url: "chronicles://../_attachments/pasted.png",
+    }));
+    mockChroniclesClient({ uploadImageBytes });
+    let lexicalEditor: LexicalEditor | null = null;
+
+    render(
+      <MemoryRouter>
+        <LexicalBasedEditor
+          initialMarkdown=""
+          onMarkdownChange={onMarkdownChange}
+          onEditorReady={(editor) => {
+            lexicalEditor = editor;
+          }}
+        />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(lexicalEditor).not.toBeNull();
+    });
+
+    const editor = screen.getByLabelText("Minimal replacement editor");
+    const file = new File(["png-bytes"], "pasted.png", { type: "image/png" });
+    await act(async () => {
+      fireEvent.focus(editor);
+      lexicalEditor!.update(() => {
+        $getRoot().selectStart();
+      });
+      lexicalEditor!.dispatchCommand(
+        PASTE_COMMAND,
+        createImagePasteEvent(file),
+      );
+    });
+
+    await waitFor(() => {
+      expect(uploadImageBytes).toHaveBeenCalledWith(
+        expect.any(ArrayBuffer),
+        "pasted.png",
+      );
+    });
+
+    const image = await screen.findByRole("img", { name: "pasted.png" });
+    expect(image.getAttribute("src")).toBe(
+      "chronicles://../_attachments/pasted.png",
+    );
+
+    await waitFor(() => {
+      expect(onMarkdownChange).toHaveBeenCalled();
+    });
+    const latestMarkdown = onMarkdownChange.mock.calls.at(-1)?.[0] as
+      | string
+      | undefined;
+    expect(latestMarkdown).toContain(
+      "![pasted.png](../_attachments/pasted.png)",
+    );
   });
 
   it("creates a link from selected text when pasting a URL", async () => {

--- a/src/views/edit/lexical/lexicalMarkdown.ts
+++ b/src/views/edit/lexical/lexicalMarkdown.ts
@@ -88,7 +88,8 @@ export const CHRONICLES_IMAGE_TRANSFORMER: ElementTransformer = {
       .getAltText()
       .replace(/\[/g, "\\[")
       .replace(/\]/g, "\\]");
-    return `![${altText}](${unPrefixUrl(node.getSrc())})`;
+    const src = unPrefixUrl(node.getSrc()).replace(/\)/g, "%29");
+    return `![${altText}](${src})`;
   },
   regExp: IMAGE_ELEMENT_REGEXP,
   replace: (parentNode, _children, match) => {

--- a/src/views/edit/lexical/lexicalMarkdown.ts
+++ b/src/views/edit/lexical/lexicalMarkdown.ts
@@ -6,6 +6,7 @@ import {
   $convertToMarkdownString,
   LINK,
   TRANSFORMERS,
+  type ElementTransformer,
   type TextMatchTransformer,
   type Transformer,
 } from "@lexical/markdown";
@@ -18,13 +19,20 @@ import {
   type LexicalNode,
   type TextNode,
 } from "lexical";
+import { prefixUrl, unPrefixUrl } from "../../../hooks/images";
 import { parseNoteLink } from "../editorv2/features/note-linking/toMdast";
+import {
+  $createChroniclesImageNode,
+  $isChroniclesImageNode,
+  ChroniclesImageNode,
+} from "./ChroniclesImageNode";
 import {
   $createChroniclesNoteLinkNode,
   $isChroniclesNoteLinkNode,
   ChroniclesNoteLinkNode,
 } from "./ChroniclesNoteLinkNode";
 
+const IMAGE_ELEMENT_REGEXP = /^!\[([^[\]]*)\]\(([^()\s]+)\)\s?$/;
 const NOTE_LINK_IMPORT_REGEXP =
   /(?:\[([^[\]]*(?:\[[^[\]]*\][^[\]]*)*)\])(?:\((\.\.\/[^()\s]+\.md)(?:\s"((?:[^"]*\\")*[^"]*)"\s*)?\))/;
 const NOTE_LINK_SHORTCUT_REGEXP =
@@ -62,6 +70,36 @@ function createLinkTextNode(node: TextNode, match: RegExpMatchArray) {
   return contentNode;
 }
 
+function normalizeImageSource(url: string): string {
+  if (url.startsWith("chronicles://")) {
+    return url;
+  }
+  return prefixUrl(url);
+}
+
+export const CHRONICLES_IMAGE_TRANSFORMER: ElementTransformer = {
+  dependencies: [ChroniclesImageNode],
+  export: (node) => {
+    if (!$isChroniclesImageNode(node)) {
+      return null;
+    }
+
+    const altText = node
+      .getAltText()
+      .replace(/\[/g, "\\[")
+      .replace(/\]/g, "\\]");
+    return `![${altText}](${unPrefixUrl(node.getSrc())})`;
+  },
+  regExp: IMAGE_ELEMENT_REGEXP,
+  replace: (parentNode, _children, match) => {
+    const [, altText, src] = match;
+    parentNode.replace(
+      $createChroniclesImageNode(normalizeImageSource(src), altText),
+    );
+  },
+  type: "element",
+};
+
 export const CHRONICLES_NOTE_LINK_TRANSFORMER: TextMatchTransformer = {
   dependencies: [ChroniclesNoteLinkNode],
   export: (node, exportChildren) => {
@@ -98,10 +136,12 @@ export const lexicalNodes: Array<Klass<LexicalNode>> = [
   CodeHighlightNode,
   LinkNode,
   AutoLinkNode,
+  ChroniclesImageNode,
   ChroniclesNoteLinkNode,
 ];
 
 export const chroniclesLexicalTransformers: Transformer[] = [
+  CHRONICLES_IMAGE_TRANSFORMER,
   CHRONICLES_NOTE_LINK_TRANSFORMER,
   ...TRANSFORMERS,
 ];

--- a/src/views/edit/lexical/lexicalMarkdown.ts
+++ b/src/views/edit/lexical/lexicalMarkdown.ts
@@ -86,6 +86,7 @@ export const CHRONICLES_IMAGE_TRANSFORMER: ElementTransformer = {
 
     const altText = node
       .getAltText()
+      .replace(/\\/g, "\\\\")
       .replace(/\[/g, "\\[")
       .replace(/\]/g, "\\]");
     const src = unPrefixUrl(node.getSrc()).replace(/\)/g, "%29");


### PR DESCRIPTION
## Summary
- add `ChroniclesImageNode` and `LexicalImageUploadPlugin` for image drop/paste in Lexical mode
- switch image markdown handling to an `ElementTransformer` so image nodes serialize correctly during markdown export
- normalize image URLs on import/export (`../_attachments/...` <-> `chronicles://../_attachments/...`) to match existing editor behavior
- add/expand Lexical tests for image roundtrip, URL normalization, render from relative markdown, and drop/paste persistence assertions
- update `docs/designs/lexical-evaluation.md` with current Lexical status and Phase 5 image completion
- include a small type-safe fix in `LexicalBlockShortcutsPlugin`

## Testing
- `bun run test src/views/edit/lexical/lexical.vitest.tsx`
- `bun run lint`
