### PR TITLE
docs: Electron reference, HTTP file server design, tsconfig fixes

### DIFF
--- a/docs/designs/lexical-evaluation.md
+++ b/docs/designs/lexical-evaluation.md
@@ -105,7 +105,7 @@ Note link navigation and markdown IO already work. This phase completes the crea
 
 ### Phase 5 — Images
 
-Images are local-first: stored as attachments, referenced via `chronicles://` URLs.
+Images are local-first: stored as attachments on disk. At render time, relative paths are translated to loadable URLs. Currently this uses `chronicles://` protocol (Electron) or will use `http://localhost:{port}/` (Electrobun — see `docs/plans/pending/electrobun-migration.md` "Local File Server Design"). The translation layer lives in `src/hooks/images.tsx` (`prefixUrl` / `unPrefixUrl`) and is transparent to the editor — Lexical image nodes just receive a src URL.
 
 | Feature                  | Status                                                                                                  |
 | ------------------------ | ------------------------------------------------------------------------------------------------------- |
@@ -162,7 +162,7 @@ Plate groups consecutive images into a lightbox gallery automatically.
 | Video drag-and-drop | Extend media upload plugin for video MIME types                      |
 | File links          | Drop non-image/video files → insert as link with "File: {name}" text |
 
-**Defer:** Video is low-priority. Plate's video support was already broken. Implement basic rendering; skip upload if time-constrained.
+**Defer (P1/P2):** Video is not a ship blocker. Plate's video support was already broken, and video seeking was broken in Electron's protocol handler too. The Electrobun HTTP file server will handle video better (native HTTP Range request support), but implementing video can happen after the Lexical and Electrobun migrations ship. Implement basic rendering if convenient; skip upload.
 
 **Vitests:**
 

--- a/docs/electron-reference.md
+++ b/docs/electron-reference.md
@@ -1,0 +1,171 @@
+# Electron Reference
+
+How Chronicles ran on Electron. Keep this around in case we need to roll back from Electrobun.
+
+---
+
+## Architecture
+
+Electron runs two Node.js processes sharing a Chromium webview:
+
+```
+Main process (src/electron/index.ts)
+  ├── BrowserWindow — creates the app window
+  ├── protocol.registerFileProtocol("chronicles") — serves local files
+  ├── ipcMain handlers — directory/file dialogs, native theme, shell open
+  ├── app lifecycle — ready, window-all-closed, activate
+  └── CSP headers — content security policy per environment
+
+Preload (src/preload/index.ts)
+  ├── contextBridge.exposeInMainWorld("chronicles", {...})
+  ├── getClient() → IClient backed by knex + better-sqlite3
+  └── 13 utility methods (dialogs, themes, fonts, shell)
+```
+
+The renderer (React) calls `window.chronicles.*` which the preload script exposes. The preload runs in a privileged context with access to Node.js APIs and Electron IPC, but the renderer itself has `nodeIntegration: false` and `contextIsolation: true`.
+
+---
+
+## chronicles:// Protocol Handler
+
+The centerpiece of local file serving. Markdown stores relative paths like `../_attachments/image.png`. At render time, `src/hooks/images.tsx` prepends `chronicles://` to make `chronicles://../_attachments/image.png`. Electron intercepts this via a custom protocol handler.
+
+### How it worked
+
+```typescript
+// src/electron/index.ts
+protocol.registerFileProtocol("chronicles", (request, callback) => {
+  const path = validateChroniclesUrl(request.url);
+  callback({ path: path ?? undefined });
+});
+```
+
+### URL routing
+
+| URL prefix                                  | Resolves to                           |
+| ------------------------------------------- | ------------------------------------- |
+| `chronicles://../_attachments/foo.png`      | `{notesDir}/_attachments/foo.png`     |
+| `chronicles://../_settings/fonts/bar.woff2` | `{settingsDir}/fonts/bar.woff2`       |
+| Anything else                               | Blocked (logged warning, returns 404) |
+
+### Security
+
+- **Directory traversal protection:** Resolved path is checked against the base directory via `path.relative()` — rejects any path that escapes with `..`
+- **Existence check:** Returns 404 if file doesn't exist on disk
+- **Allowlist:** Only `_attachments` and `_settings/fonts` prefixes are accepted
+
+### CSP integration
+
+The Content Security Policy explicitly allows `chronicles://*` in `img-src`, `media-src`, `font-src`, and `connect-src` directives. In dev mode, the Vite dev server origin is also added.
+
+### Known limitation
+
+`registerFileProtocol` was deprecated in favor of `protocol.handle()`, but the newer API broke video seeking. The deprecated API was kept for video compatibility (which was already marginal).
+
+---
+
+## Preload Bridge (the RPC layer)
+
+Electron's `contextBridge.exposeInMainWorld` creates a serialization-safe bridge between the preload context (has Node.js) and the renderer (pure browser).
+
+### window.chronicles API
+
+| Method                              | Category   | Implementation                                                     |
+| ----------------------------------- | ---------- | ------------------------------------------------------------------ |
+| `getClient()`                       | Core       | Returns IClient singleton (knex + better-sqlite3 + electron-store) |
+| `openDialogSelectDir()`             | Dialog     | IPC to main → `dialog.showOpenDialog`                              |
+| `selectThemeFile()`                 | Dialog     | IPC to main → `dialog.showOpenDialog` with JSON filter             |
+| `importThemeFile(path, dir)`        | Filesystem | `fs.copyFileSync` in preload                                       |
+| `listAvailableThemes(dir)`          | Filesystem | `fs.readdirSync` in preload                                        |
+| `loadThemeByName(name, dir)`        | Filesystem | `fs.readFileSync` + JSON.parse in preload                          |
+| `deleteThemeByName(name, dir)`      | Filesystem | `fs.unlinkSync` in preload                                         |
+| `listHljsThemes()`                  | Filesystem | Read from bundled hljs-themes dir                                  |
+| `loadHljsThemeCSS(name)`            | Filesystem | Read CSS file contents                                             |
+| `listInstalledFonts()`              | Filesystem | Scan fonts directory                                               |
+| `getInstalledFontsStylesheetHref()` | Filesystem | Return `file://` URL for fonts.css                                 |
+| `refreshInstalledFontsCache()`      | Filesystem | Regenerate fonts.css from font dir                                 |
+| `openPath(path)`                    | Shell      | IPC to main → `shell.openPath`                                     |
+| `setNativeTheme(mode)`              | Native     | IPC to main → `nativeTheme.themeSource = mode`                     |
+
+### Key detail: IClient ran in-process
+
+In Electron, `getClient()` returned a client backed by `knex` + `better-sqlite3` running **directly in the preload process** (same V8 isolate as the renderer, but with Node.js access). No serialization, no IPC — just direct function calls. This made the `IClient` interface synchronous-feeling even though methods return Promises.
+
+In Electrobun, this becomes true RPC: the renderer calls through Electrobun's typed RPC to the Bun main process, which runs `BunClient` (drizzle + bun:sqlite). The `window.chronicles` shape stays identical — only the transport changes.
+
+---
+
+## Main Process Behaviors
+
+### Window configuration
+
+```typescript
+new BrowserWindow({
+  backgroundColor: "#121212",
+  show: false, // hide until ready-to-show to avoid white flash
+  width: 800,
+  height: 800,
+  titleBarStyle: "hidden",
+  trafficLightPosition: { x: 10, y: 16 },
+  webPreferences: {
+    nodeIntegration: false,
+    sandbox: false,
+    contextIsolation: true,
+    preload: "preload.bundle.mjs",
+  },
+});
+```
+
+### Link handling
+
+All navigation from the renderer is intercepted:
+
+- `chronicles://` links → validate, then `shell.showItemInFolder`
+- `http://` / `https://` / `mailto:` → `shell.openExternal`
+- Everything else → blocked
+
+New window creation is denied (`setWindowOpenHandler` returns `{ action: "deny" }`).
+
+### Context menu
+
+`electron-context-menu` package provided right-click menu with Cut/Copy/Paste, spell checking suggestions, "Look Up", and "Search with Google".
+
+### Native dependencies
+
+| Package          | Why                                               | Electrobun replacement  |
+| ---------------- | ------------------------------------------------- | ----------------------- |
+| `better-sqlite3` | SQLite driver (C++ addon, needs electron-rebuild) | `bun:sqlite` (built-in) |
+| `sharp`          | Image resize/convert on upload                    | Dropped (passthrough)   |
+| `electron-store` | Persistent key-value settings                     | JSON file read/write    |
+| `knex`           | SQL query builder for better-sqlite3              | Drizzle ORM             |
+
+---
+
+## Build & Package Pipeline
+
+```
+build.sh:
+  1. esbuild bundles main + preload → src/main.bundle.mjs, src/preload.bundle.mjs
+  2. vite build → dist/renderer/
+  3. Copy bundles + package.json + yarn.lock into dist/
+  4. yarn install in dist/ (installs runtime deps for packaged app)
+  5. electron-packager bundles into .app with embedded Chromium + Node
+```
+
+The packaged app is ~100MB+, mostly Chromium.
+
+---
+
+## Rolling Back
+
+If we need to return to Electron:
+
+1. Restore `src/electron/index.ts` and `src/preload/` from git history
+2. Re-add Electron deps: `electron`, `@electron/packager`, `@electron/rebuild`, `better-sqlite3`, `knex`, `electron-store`, `electron-context-menu`, `sharp`
+3. Re-add `postinstall: "electron-rebuild"` script
+4. Restore `build.sh` Electron packaging steps
+5. Restore `scripts/dev.mjs` Electron process spawning
+6. The renderer (`src/views/`) needs zero changes — `window.chronicles` is the same shape
+7. `src/bun-client/` can stay — it's independent. But the Electron preload would use the old knex client.
+
+The hard part of rolling back is native module rebuild configuration, not code. The architecture was designed so the renderer doesn't know or care which shell it runs in.

--- a/docs/plans/pending/electrobun-migration.md
+++ b/docs/plans/pending/electrobun-migration.md
@@ -170,7 +170,7 @@ All modules ported to Drizzle ORM + bun:sqlite: journals, documents, tags, prefe
 **Steps:**
 
 1. **QA in dev mode:** Launch `electrobun dev` + Vite, test all features against checklist
-2. **Fix `chronicles://` protocol:** Replace with RPC + data URLs for images and base64 fonts
+2. **Replace `chronicles://` protocol:** Local HTTP file server (see design below)
 3. **Configure Electrobun build:** `electrobun build --env=stable`, bundled assets, Drizzle migrations
 4. **Code signing:** `build.mac.codesign: true` in `electrobun.config.ts`
 5. **Test production build:** App launches from built bundle, all features work
@@ -200,6 +200,79 @@ All modules ported to Drizzle ORM + bun:sqlite: journals, documents, tags, prefe
 - [ ] Startup time < 100ms
 
 **Docs needed:** Electrobun Build & Distribute
+
+---
+
+## Local File Server Design (chronicles:// replacement)
+
+### Background
+
+Electron served local files (images, fonts) via a custom `chronicles://` protocol handler. Electrobun wraps WKWebView and doesn't expose `WKURLSchemeHandler` for custom URL schemes. The idiomatic alternative across frameworks is a custom protocol, but since Electrobun doesn't offer one, we use a localhost HTTP server on Bun.
+
+### Architecture
+
+The Bun main process starts a local HTTP file server on app launch. The renderer uses `http://localhost:{port}/` URLs where it previously used `chronicles://` URLs.
+
+```
+Bun main process
+  ├── Electrobun BrowserWindow (webview)
+  └── Bun.serve() on localhost:{dynamic_port}
+        ├── GET /attachments/{path} → notesDir/_attachments/{path}
+        └── GET /fonts/{path}       → settingsDir/fonts/{path}
+```
+
+### Port selection
+
+Use port 0 to let the OS assign an available port. Pass the resolved port to the renderer via RPC on startup (e.g. `rpc.request.getFileServerPort()` or inject as a global before page load).
+
+```typescript
+const server = Bun.serve({
+  port: 0, // OS assigns available port
+  fetch(req) {
+    /* ... */
+  },
+});
+const port = server.port; // actual assigned port
+```
+
+### URL translation
+
+`src/hooks/images.tsx` currently does:
+
+```typescript
+// Before (Electron):  chronicles://../_attachments/foo.png
+// After (Electrobun): http://localhost:{port}/attachments/foo.png
+```
+
+The `prefixUrl()` / `unPrefixUrl()` functions change to use the HTTP base URL. On disk, markdown files continue to store relative paths (`../_attachments/foo.png`). The translation is render-time only.
+
+### Security
+
+1. **Bind to localhost only** — not reachable from the network
+2. **Path validation** — same directory traversal checks as the Electron handler: resolve the path, verify it's within the allowed base directory
+3. **Allowlisted prefixes only** — only `/attachments/` and `/fonts/` are routed; everything else returns 404
+4. **CORS** — set `Access-Control-Allow-Origin` to the Vite dev server origin (dev) or the webview origin (prod)
+
+### CSP
+
+Update Content Security Policy to allow `http://localhost:*` in `img-src`, `media-src`, `font-src` instead of `chronicles://*`.
+
+### Renderer integration
+
+The renderer needs to know the server port. Options:
+
+- **RPC on startup:** `window.chronicles.getFileServerPort()` — simplest, already have the RPC channel
+- **Injected global:** Set `window.__CHRONICLES_FILE_SERVER_PORT__` before the page loads
+
+Then `prefixUrl()` builds URLs like `http://localhost:${port}/attachments/${relativePath}`.
+
+### Video
+
+Video serving is P1/P2 — not a ship blocker. Video doesn't work well in the current Electron build either (seeking broken on `registerFileProtocol`). When we do implement it, the HTTP server naturally supports `Range` requests for video seeking, which is actually an improvement over the Electron protocol handler.
+
+### Font serving
+
+Fonts currently use `chronicles://../_settings/fonts/` URLs in a generated `fonts.css` stylesheet. With the HTTP server, `fonts.css` generation changes to emit `http://localhost:{port}/fonts/` URLs instead. Or: inject font data as base64 `@font-face` blocks via RPC at startup (avoids server dependency for fonts). Either approach works.
 
 ---
 
@@ -259,7 +332,7 @@ The migration end-state is **deletion, not refactoring** — when Electrobun pas
 
 1. ~~**Knex + bun:sqlite:**~~ **Resolved.** Knex has no bun:sqlite support. We chose Drizzle ORM (`drizzle-orm/bun-sqlite`). Phase 1 is complete with 106/106 tests passing.
 
-2. **`chronicles://` protocol:** ~~How does Electrobun handle custom URL schemes / local file serving in webviews?~~ **Resolved:** There is no `registerFileProtocol` equivalent. `urlSchemes` in `electrobun.config.ts` is deep-link only (external app-launch URLs). The solution is RPC + data URLs: images are fetched via RPC and displayed as `data:` URLs (Lexical controls rendering); fonts are fetched via RPC at startup and injected as `<style>` blocks with base64 `@font-face` data. See `docs/vendor/electrobun/browser-view-window.md` for details.
+2. **`chronicles://` protocol:** ~~How does Electrobun handle custom URL schemes / local file serving in webviews?~~ **Resolved:** There is no `registerFileProtocol` equivalent. Electrobun doesn't expose `WKURLSchemeHandler` to user code. Solution: local HTTP file server on Bun (see design below).
 
 ---
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -69,5 +69,10 @@
     "skipLibCheck": true /* Skip type checking of declaration files. */,
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */,
   },
-  "exclude": ["src/bun-client"],
+  "exclude": [
+    "src/bun-client",
+    "src/electrobun",
+    "electrobun.config.ts",
+    "scripts/build-electrobun-main.ts",
+  ],
 }


### PR DESCRIPTION
## Summary

- **Electron reference doc** (`docs/electron-reference.md`): Documents how the Electron shell worked — chronicles:// protocol handler, preload bridge, main process behaviors, native dependencies, and rollback instructions. Keeps this knowledge accessible if we need to revert from Electrobun.
- **HTTP file server design** (in `docs/plans/pending/electrobun-migration.md`): Replaces the previous "RPC + data URLs" plan for serving local files. Covers dynamic port selection, URL translation, security (localhost-only, path validation, allowlisted prefixes), CSP, and renderer integration. Video is deprioritized to P1/P2 post-ship.
- **Lexical plan update** (`docs/designs/lexical-evaluation.md`): Notes that image URLs are transport-agnostic — Lexical nodes receive a src URL regardless of whether the backend uses chronicles:// or HTTP.
- **tsconfig fix**: Excludes `src/electrobun/`, `electrobun.config.ts`, and `scripts/build-electrobun-main.ts` from the root tsconfig so `bun run lint` passes cleanly. These files use Bun/Electrobun-specific APIs (`bun:sqlite`, `import.meta.dir`, `electrobun/bun`) that tsc doesn't understand.

## Test plan

- [x] `bun run lint` — zero errors
- [x] `bun run test` — 73/73 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)