### PR TITLE
fix: detect duplicate document IDs across journals

### DIFF
--- a/src/hooks/stores/indexer.ts
+++ b/src/hooks/stores/indexer.ts
@@ -43,7 +43,7 @@ export class IndexerStore {
       toastId = toast.loading("Indexing notes...");
 
       // Call underlying client index
-      await this.client.indexer.index(fullReindex);
+      const { duplicateCount } = await this.client.indexer.index(fullReindex);
 
       // Update last index time
       this.lastIndexTime = new Date();
@@ -53,7 +53,13 @@ export class IndexerStore {
 
       // Dismiss loading toast and show success
       toast.dismiss(toastId);
-      toast.success("Index updated");
+      if (duplicateCount > 0) {
+        toast.warning(
+          `Index updated — ${duplicateCount} duplicate document(s) found in multiple journals. Check logs for details.`,
+        );
+      } else {
+        toast.success("Index updated");
+      }
     } catch (err: any) {
       console.error("Error during indexing:", err);
       this.error = err;

--- a/src/node-client/indexer.ts
+++ b/src/node-client/indexer.ts
@@ -66,7 +66,7 @@ export class IndexerClient {
    *
    * @param fullReindex - If true, skip mtime/hash optimizations and re-parse all documents.
    */
-  index = async (fullReindex = false): Promise<void> => {
+  index = async (fullReindex = false): Promise<{ duplicateCount: number }> => {
     const [{ id: syncId }] = await this.db
       .insert(sync)
       .values({})
@@ -93,7 +93,9 @@ export class IndexerClient {
     const knownJournals = await this.initJournalsCounter();
     const journalsOnDisk: Record<string, number> = {};
 
-    const seenDocumentIds = new Set<string>();
+    // Track document ID → journal for duplicate detection
+    const seenDocumentIds = new Map<string, string>();
+    const duplicateDocumentIds = new Map<string, string[]>();
     const erroredDocumentPaths: string[] = [];
 
     let indexedCount = 0;
@@ -109,9 +111,24 @@ export class IndexerClient {
         continue;
       }
 
-      seenDocumentIds.add(documentId);
-
       const dirname = path.basename(dir);
+
+      // Duplicate detection: same document ID in multiple journals
+      const previousJournal = seenDocumentIds.get(documentId);
+      if (previousJournal) {
+        const existing = duplicateDocumentIds.get(documentId);
+        if (existing) {
+          existing.push(dirname);
+        } else {
+          duplicateDocumentIds.set(documentId, [previousJournal, dirname]);
+        }
+        console.error(
+          `[indexer] Duplicate document ID "${documentId}" found in journals: ${previousJournal}, ${dirname}. Skipping duplicate.`,
+        );
+        continue;
+      }
+
+      seenDocumentIds.set(documentId, dirname);
 
       // Track journal as seen on disk; create in DB if unknown
       if (!(dirname in journalsOnDisk)) {
@@ -182,8 +199,19 @@ export class IndexerClient {
       }
     }
 
+    if (duplicateDocumentIds.size > 0) {
+      console.warn(
+        `[indexer] ${duplicateDocumentIds.size} document(s) exist in multiple journals — check logs for details`,
+      );
+    }
+
     // Delete documents that no longer exist on disk
-    await this.documents.deleteOrphanedDocuments(seenDocumentIds);
+    const seenIds = new Set(seenDocumentIds.keys());
+    // Include duplicate IDs so they aren't treated as orphaned
+    for (const id of duplicateDocumentIds.keys()) {
+      seenIds.add(id);
+    }
+    await this.documents.deleteOrphanedDocuments(seenIds);
 
     // Clean up orphaned journals
     await this.cleanupOrphanedJournals(journalsOnDisk);
@@ -227,6 +255,8 @@ export class IndexerClient {
         durationMs,
       })
       .where(eq(sync.id, syncId));
+
+    return { duplicateCount: duplicateDocumentIds.size };
   };
 
   private initJournalsCounter = async (): Promise<Record<string, number>> => {


### PR DESCRIPTION
## Summary

- **Root cause:** Documents with the same filename (UUID) in multiple journal directories caused the indexer to silently overwrite DB rows on each reindex — last-writer-wins corrupted journal assignments and emptied content
- **Fix:** Indexer now tracks seen document IDs during walk; duplicates are skipped with `console.error` logging identifying both journals. A single toast warns the user to check logs.
- **Data fix:** Deleted the two empty duplicate files from `Documents_Guitar Journal/` that were causing the issue

## Test plan

- [x] `yarn lint` passes
- [x] `yarn test` passes (106 tests, 0 failures)
- [ ] Manual: place same-ID `.md` file in two journal dirs, run app, confirm toast warning appears and the first-encountered copy wins (no overwrite)
- [ ] Manual: confirm normal indexing still works with no duplicates present

🤖 Generated with [Claude Code](https://claude.com/claude-code)